### PR TITLE
Contacts background sync

### DIFF
--- a/app/schemas/chat.rocket.android.db.RCDatabase/13.json
+++ b/app/schemas/chat.rocket.android.db.RCDatabase/13.json
@@ -1,0 +1,1137 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 13,
+    "identityHash": "5a94eca489a9a851182f7f0dd77194cc",
+    "entities": [
+      {
+        "tableName": "users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `username` TEXT, `name` TEXT, `status` TEXT NOT NULL, `utcOffset` REAL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "utcOffset",
+            "columnName": "utcOffset",
+            "affinity": "REAL",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_users_username",
+            "unique": false,
+            "columnNames": [
+              "username"
+            ],
+            "createSql": "CREATE  INDEX `index_users_username` ON `${TABLE_NAME}` (`username`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "chatrooms",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `subscriptionId` TEXT NOT NULL, `type` TEXT NOT NULL, `name` TEXT NOT NULL, `fullname` TEXT, `userId` TEXT, `ownerId` TEXT, `readonly` INTEGER, `isDefault` INTEGER, `favorite` INTEGER, `open` INTEGER NOT NULL, `alert` INTEGER NOT NULL, `unread` INTEGER NOT NULL, `userMentions` INTEGER, `groupMentions` INTEGER, `updatedAt` INTEGER, `timestamp` INTEGER, `lastSeen` INTEGER, `lastMessageText` TEXT, `lastMessageUserId` TEXT, `lastMessageTimestamp` INTEGER, `broadcast` INTEGER, `muted` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`ownerId`) REFERENCES `users`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION , FOREIGN KEY(`userId`) REFERENCES `users`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION , FOREIGN KEY(`lastMessageUserId`) REFERENCES `users`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subscriptionId",
+            "columnName": "subscriptionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fullname",
+            "columnName": "fullname",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "readonly",
+            "columnName": "readonly",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isDefault",
+            "columnName": "isDefault",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "favorite",
+            "columnName": "favorite",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "open",
+            "columnName": "open",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alert",
+            "columnName": "alert",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unread",
+            "columnName": "unread",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userMentions",
+            "columnName": "userMentions",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "groupMentions",
+            "columnName": "groupMentions",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastSeen",
+            "columnName": "lastSeen",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastMessageText",
+            "columnName": "lastMessageText",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastMessageUserId",
+            "columnName": "lastMessageUserId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastMessageTimestamp",
+            "columnName": "lastMessageTimestamp",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "broadcast",
+            "columnName": "broadcast",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "muted",
+            "columnName": "muted",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_chatrooms_userId",
+            "unique": false,
+            "columnNames": [
+              "userId"
+            ],
+            "createSql": "CREATE  INDEX `index_chatrooms_userId` ON `${TABLE_NAME}` (`userId`)"
+          },
+          {
+            "name": "index_chatrooms_ownerId",
+            "unique": false,
+            "columnNames": [
+              "ownerId"
+            ],
+            "createSql": "CREATE  INDEX `index_chatrooms_ownerId` ON `${TABLE_NAME}` (`ownerId`)"
+          },
+          {
+            "name": "index_chatrooms_subscriptionId",
+            "unique": true,
+            "columnNames": [
+              "subscriptionId"
+            ],
+            "createSql": "CREATE UNIQUE INDEX `index_chatrooms_subscriptionId` ON `${TABLE_NAME}` (`subscriptionId`)"
+          },
+          {
+            "name": "index_chatrooms_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "updatedAt"
+            ],
+            "createSql": "CREATE  INDEX `index_chatrooms_updatedAt` ON `${TABLE_NAME}` (`updatedAt`)"
+          },
+          {
+            "name": "index_chatrooms_lastMessageUserId",
+            "unique": false,
+            "columnNames": [
+              "lastMessageUserId"
+            ],
+            "createSql": "CREATE  INDEX `index_chatrooms_lastMessageUserId` ON `${TABLE_NAME}` (`lastMessageUserId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "users",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "ownerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "users",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "userId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "users",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "lastMessageUserId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `roomId` TEXT NOT NULL, `message` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `senderId` TEXT, `updatedAt` INTEGER, `editedAt` INTEGER, `editedBy` TEXT, `senderAlias` TEXT, `avatar` TEXT, `type` TEXT, `groupable` INTEGER NOT NULL, `parseUrls` INTEGER NOT NULL, `pinned` INTEGER NOT NULL, `role` TEXT, `synced` INTEGER NOT NULL, `unread` INTEGER, PRIMARY KEY(`id`), FOREIGN KEY(`senderId`) REFERENCES `users`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION , FOREIGN KEY(`editedBy`) REFERENCES `users`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "roomId",
+            "columnName": "roomId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "senderId",
+            "columnName": "senderId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "editedAt",
+            "columnName": "editedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "editedBy",
+            "columnName": "editedBy",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "senderAlias",
+            "columnName": "senderAlias",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "avatar",
+            "columnName": "avatar",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "groupable",
+            "columnName": "groupable",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parseUrls",
+            "columnName": "parseUrls",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pinned",
+            "columnName": "pinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "synced",
+            "columnName": "synced",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unread",
+            "columnName": "unread",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "users",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "senderId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "users",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "editedBy"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "message_favorites",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`messageId` TEXT NOT NULL, `userId` TEXT NOT NULL, PRIMARY KEY(`messageId`, `userId`), FOREIGN KEY(`messageId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`userId`) REFERENCES `users`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "messageId",
+            "userId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "users",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "userId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "message_mentions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`messageId` TEXT NOT NULL, `userId` TEXT NOT NULL, PRIMARY KEY(`messageId`, `userId`), FOREIGN KEY(`messageId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`userId`) REFERENCES `users`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "messageId",
+            "userId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "users",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "userId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "message_channels",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`messageId` TEXT NOT NULL, `roomId` TEXT NOT NULL, `roomName` TEXT, PRIMARY KEY(`messageId`, `roomId`), FOREIGN KEY(`messageId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "roomId",
+            "columnName": "roomId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "roomName",
+            "columnName": "roomName",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "messageId",
+            "roomId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "attachments",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` TEXT NOT NULL, `message_id` TEXT NOT NULL, `title` TEXT, `type` TEXT, `description` TEXT, `text` TEXT, `author_name` TEXT, `author_icon` TEXT, `author_link` TEXT, `thumb_url` TEXT, `color` TEXT, `fallback` TEXT, `title_link` TEXT, `title_link_download` INTEGER NOT NULL, `image_url` TEXT, `image_type` TEXT, `image_size` INTEGER, `video_url` TEXT, `video_type` TEXT, `video_size` INTEGER, `audio_url` TEXT, `audio_type` TEXT, `audio_size` INTEGER, `message_link` TEXT, `timestamp` INTEGER, `has_actions` INTEGER NOT NULL, `has_fields` INTEGER NOT NULL, `button_alignment` TEXT, PRIMARY KEY(`_id`), FOREIGN KEY(`message_id`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "_id",
+            "columnName": "_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "message_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "authorName",
+            "columnName": "author_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "authorIcon",
+            "columnName": "author_icon",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "authorLink",
+            "columnName": "author_link",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "thumbUrl",
+            "columnName": "thumb_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fallback",
+            "columnName": "fallback",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "titleLink",
+            "columnName": "title_link",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "titleLinkDownload",
+            "columnName": "title_link_download",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageType",
+            "columnName": "image_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageSize",
+            "columnName": "image_size",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "videoUrl",
+            "columnName": "video_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "videoType",
+            "columnName": "video_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "videoSize",
+            "columnName": "video_size",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "audioUrl",
+            "columnName": "audio_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "audioType",
+            "columnName": "audio_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "audioSize",
+            "columnName": "audio_size",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "messageLink",
+            "columnName": "message_link",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hasActions",
+            "columnName": "has_actions",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasFields",
+            "columnName": "has_fields",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "buttonAlignment",
+            "columnName": "button_alignment",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "message_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "attachment_fields",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `attachmentId` TEXT NOT NULL, `title` TEXT NOT NULL, `value` TEXT NOT NULL, FOREIGN KEY(`attachmentId`) REFERENCES `attachments`(`_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "attachmentId",
+            "columnName": "attachmentId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_attachment_fields_attachmentId",
+            "unique": false,
+            "columnNames": [
+              "attachmentId"
+            ],
+            "createSql": "CREATE  INDEX `index_attachment_fields_attachmentId` ON `${TABLE_NAME}` (`attachmentId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "attachments",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "attachmentId"
+            ],
+            "referencedColumns": [
+              "_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "attachment_action",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `attachmentId` TEXT NOT NULL, `type` TEXT NOT NULL, `text` TEXT, `url` TEXT, `isWebView` INTEGER, `webViewHeightRatio` TEXT, `imageUrl` TEXT, `message` TEXT, `isMessageInChatWindow` INTEGER, FOREIGN KEY(`attachmentId`) REFERENCES `attachments`(`_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "attachmentId",
+            "columnName": "attachmentId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isWebView",
+            "columnName": "isWebView",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "webViewHeightRatio",
+            "columnName": "webViewHeightRatio",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isMessageInChatWindow",
+            "columnName": "isMessageInChatWindow",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_attachment_action_attachmentId",
+            "unique": false,
+            "columnNames": [
+              "attachmentId"
+            ],
+            "createSql": "CREATE  INDEX `index_attachment_action_attachmentId` ON `${TABLE_NAME}` (`attachmentId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "attachments",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "attachmentId"
+            ],
+            "referencedColumns": [
+              "_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "urls",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`urlId` INTEGER PRIMARY KEY AUTOINCREMENT, `messageId` TEXT NOT NULL, `url` TEXT NOT NULL, `hostname` TEXT, `title` TEXT, `description` TEXT, `imageUrl` TEXT, FOREIGN KEY(`messageId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "urlId",
+            "columnName": "urlId",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostname",
+            "columnName": "hostname",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "urlId"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_urls_messageId",
+            "unique": false,
+            "columnNames": [
+              "messageId"
+            ],
+            "createSql": "CREATE  INDEX `index_urls_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "reactions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`reaction` TEXT NOT NULL, `messageId` TEXT NOT NULL, `count` INTEGER NOT NULL, `usernames` TEXT NOT NULL, PRIMARY KEY(`reaction`), FOREIGN KEY(`messageId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "reaction",
+            "columnName": "reaction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "usernames",
+            "columnName": "usernames",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "reaction"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_reactions_messageId",
+            "unique": false,
+            "columnNames": [
+              "messageId"
+            ],
+            "createSql": "CREATE  INDEX `index_reactions_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "messages_sync",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`roomId` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`roomId`))",
+        "fields": [
+          {
+            "fieldPath": "roomId",
+            "columnName": "roomId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "roomId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "contacts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT, `username` TEXT, `phoneNumber` TEXT, `emailAddress` TEXT, `isPhone` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phoneNumber",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "emailAddress",
+            "columnName": "emailAddress",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isPhone",
+            "columnName": "isPhone",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"5a94eca489a9a851182f7f0dd77194cc\")"
+    ]
+  }
+}

--- a/app/src/main/java/chat/rocket/android/contacts/di/ContactSyncSubComponent.kt
+++ b/app/src/main/java/chat/rocket/android/contacts/di/ContactSyncSubComponent.kt
@@ -1,0 +1,10 @@
+package chat.rocket.android.contacts.di
+import chat.rocket.android.contacts.worker.ContactSyncWorker
+import dagger.Subcomponent
+import dagger.android.AndroidInjector
+
+@Subcomponent
+interface ContactSyncSubComponent : AndroidInjector<ContactSyncWorker> {
+    @Subcomponent.Builder
+    abstract class Builder : AndroidInjector.Builder<ContactSyncWorker>()
+}

--- a/app/src/main/java/chat/rocket/android/contacts/models/Contact.kt
+++ b/app/src/main/java/chat/rocket/android/contacts/models/Contact.kt
@@ -10,6 +10,7 @@ class Contact() : Parcelable {
     private var phoneNumber: String? = null
     private var emailAddress: String? = null
     private var isPhone: Boolean = true
+    private var username: String? = null
 
     fun getDetail(): String? {
         if(this.isPhone){
@@ -27,12 +28,20 @@ class Contact() : Parcelable {
         return name
     }
 
+    fun getUsername(): String? {
+        return username
+    }
+
     fun setId(id: Int) {
         this.id = id
     }
 
     fun setName(name: String) {
         this.name = name
+    }
+
+    fun setUsername(username: String) {
+        this.username = username
     }
 
     fun setIsPhone(isPhone: Boolean) {

--- a/app/src/main/java/chat/rocket/android/contacts/models/Contact.kt
+++ b/app/src/main/java/chat/rocket/android/contacts/models/Contact.kt
@@ -11,12 +11,32 @@ class Contact() : Parcelable {
     private var emailAddress: String? = null
     private var isPhone: Boolean = true
 
+    fun getDetail(): String? {
+        if(this.isPhone){
+            return getPhoneNumber()
+        }else{
+            return getEmailAddress()
+        }
+    }
+
+    fun getId(): Int {
+        return id
+    }
+
     fun getName(): String? {
         return name
     }
 
+    fun setId(id: Int) {
+        this.id = id
+    }
+
     fun setName(name: String) {
         this.name = name
+    }
+
+    fun setIsPhone(isPhone: Boolean) {
+        this.isPhone = isPhone
     }
 
     fun getPhoneNumber(): String? {

--- a/app/src/main/java/chat/rocket/android/contacts/models/Contact.kt
+++ b/app/src/main/java/chat/rocket/android/contacts/models/Contact.kt
@@ -12,6 +12,10 @@ class Contact() : Parcelable {
     private var isPhone: Boolean = true
     private var username: String? = null
 
+    private fun formatPhoneNumber(phone: String): String {
+        return phone.replace("-|\\s|\\(|\\)".toRegex(), "")
+    }
+
     fun getDetail(): String? {
         if(this.isPhone){
             return getPhoneNumber()
@@ -53,7 +57,7 @@ class Contact() : Parcelable {
     }
 
     fun setPhoneNumber(phoneNumber: String) {
-        this.phoneNumber = phoneNumber
+        this.phoneNumber = formatPhoneNumber(phoneNumber)
     }
 
     fun getEmailAddress(): String? {

--- a/app/src/main/java/chat/rocket/android/contacts/models/Contact.kt
+++ b/app/src/main/java/chat/rocket/android/contacts/models/Contact.kt
@@ -29,7 +29,7 @@ class Contact() : Parcelable {
     }
 
     fun getUsername(): String? {
-        return username
+        return this.username
     }
 
     fun setId(id: Int) {
@@ -40,7 +40,7 @@ class Contact() : Parcelable {
         this.name = name
     }
 
-    fun setUsername(username: String) {
+    fun setUsername(username: String?) {
         this.username = username
     }
 

--- a/app/src/main/java/chat/rocket/android/contacts/worker/ContactSyncWorker.kt
+++ b/app/src/main/java/chat/rocket/android/contacts/worker/ContactSyncWorker.kt
@@ -1,0 +1,103 @@
+package chat.rocket.android.contacts.worker
+
+import android.content.Context
+import android.provider.ContactsContract
+import androidx.work.Data
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+import chat.rocket.android.app.RocketChatApplication
+import chat.rocket.android.contacts.models.Contact
+import chat.rocket.android.dagger.injector.AndroidWorkerInjection
+import chat.rocket.android.db.DatabaseManager
+import chat.rocket.android.db.DatabaseManagerFactory
+import chat.rocket.android.draw.dagger.DaggerAppComponent
+import chat.rocket.android.server.domain.GetAccountsInteractor
+import chat.rocket.android.server.domain.GetCurrentServerInteractor
+import dagger.Module
+import dagger.android.AndroidInjection
+import timber.log.Timber
+import java.util.ArrayList
+import javax.inject.Inject
+
+class ContactSyncWorker(context : Context, params : WorkerParameters)
+    : Worker(context, params) {
+    @Inject
+    lateinit var dbFactory: DatabaseManagerFactory
+    @Inject
+    lateinit var serverInteractor: GetCurrentServerInteractor
+    @Inject
+    lateinit var getAccountsInteractor: GetAccountsInteractor
+
+    private var contactArrayList: ArrayList<Contact> = ArrayList()
+
+    override fun doWork(): Result {
+        AndroidWorkerInjection.inject(this)
+
+        getContactList()
+
+        val dbManager = dbFactory.create(serverInteractor.get()!!)
+        dbManager.processContacts(contactArrayList)
+
+        Timber.d("Contacts fetched in background.")
+
+
+        return Result.SUCCESS
+    }
+
+
+
+    private fun getContactList() {
+        val cr = applicationContext.contentResolver
+
+        val cur = cr.query(ContactsContract.Contacts.CONTENT_URI, null, null, null, null)
+
+        if ((cur?.count ?: 0) > 0) {
+            while (cur != null && cur.moveToNext()) {
+                val id = cur.getString(
+                        cur.getColumnIndex(ContactsContract.Contacts._ID))
+                val name = cur.getString(cur.getColumnIndex(
+                        ContactsContract.Contacts.DISPLAY_NAME))
+
+                if (cur.getInt(cur.getColumnIndex(ContactsContract.Contacts.HAS_PHONE_NUMBER)) > 0) {
+                    // Has phone numbers
+
+                    val pCur = cr.query(
+                            ContactsContract.CommonDataKinds.Phone.CONTENT_URI, null,
+                            ContactsContract.CommonDataKinds.Phone.CONTACT_ID + " = ?",
+                            arrayOf<String>(id), null)
+                    while (pCur!!.moveToNext()) {
+                        val phoneNo = pCur.getString(pCur.getColumnIndex(
+                                ContactsContract.CommonDataKinds.Phone.NUMBER))
+                        val contact = Contact()
+                        contact.setName(name)
+                        contact.setPhoneNumber(phoneNo)
+                        contactArrayList.add(contact)
+                    }
+                    pCur.close()
+                }
+
+                if (true) {
+                    // No check for having email address
+
+                    val eCur = cr.query(
+                            ContactsContract.CommonDataKinds.Email.CONTENT_URI, null,
+                            ContactsContract.CommonDataKinds.Email.CONTACT_ID + " = ?",
+                            arrayOf<String>(id), null)
+                    while (eCur!!.moveToNext()) {
+                        val emailID = eCur.getString(eCur.getColumnIndex(
+                                ContactsContract.CommonDataKinds.Email.DATA))
+                        val contact = Contact()
+                        contact.setName(name)
+                        contact.setEmailAddress(emailID)
+                        contactArrayList.add(contact)
+                    }
+                    eCur.close()
+                }
+            }
+        }
+        cur?.close()
+        contactArrayList.sortWith(Comparator { o1, o2 ->
+            o1.getName()!!.compareTo(o2.getName()!!)
+        })
+    }
+}

--- a/app/src/main/java/chat/rocket/android/dagger/AppComponent.kt
+++ b/app/src/main/java/chat/rocket/android/dagger/AppComponent.kt
@@ -8,6 +8,7 @@ import chat.rocket.android.dagger.module.AndroidWorkerInjectionModule
 import chat.rocket.android.dagger.module.AppModule
 import chat.rocket.android.dagger.module.ReceiverBuilder
 import chat.rocket.android.dagger.module.ServiceBuilder
+import chat.rocket.android.dagger.module.WorkerBuilder
 import dagger.BindsInstance
 import dagger.Component
 import dagger.android.support.AndroidSupportInjectionModule
@@ -16,7 +17,7 @@ import javax.inject.Singleton
 @Singleton
 @Component(modules = [AndroidSupportInjectionModule::class,
     AppModule::class, ActivityBuilder::class, ServiceBuilder::class, ReceiverBuilder::class,
-    AndroidWorkerInjectionModule::class])
+    AndroidWorkerInjectionModule::class, WorkerBuilder::class])
 interface AppComponent {
 
     @Component.Builder

--- a/app/src/main/java/chat/rocket/android/dagger/module/WorkerBuilder.kt
+++ b/app/src/main/java/chat/rocket/android/dagger/module/WorkerBuilder.kt
@@ -1,0 +1,21 @@
+package chat.rocket.android.dagger.module
+
+import androidx.work.Worker
+import chat.rocket.android.contacts.di.ContactSyncSubComponent
+import chat.rocket.android.contacts.worker.ContactSyncWorker
+import chat.rocket.android.dagger.qualifier.WorkerKey
+import dagger.Binds
+import dagger.Module
+import dagger.android.AndroidInjector
+import dagger.multibindings.IntoMap
+
+
+@Module(subcomponents = [ContactSyncSubComponent::class])
+abstract class WorkerBuilder {
+    @Binds
+    @IntoMap
+    @WorkerKey(ContactSyncWorker::class)
+    abstract fun bindContactSyncWorkerFactory(
+            builder: ContactSyncSubComponent.Builder
+    ): AndroidInjector.Factory<out Worker>
+}

--- a/app/src/main/java/chat/rocket/android/db/ContactDao.kt
+++ b/app/src/main/java/chat/rocket/android/db/ContactDao.kt
@@ -1,0 +1,26 @@
+package chat.rocket.android.db
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Transaction
+import chat.rocket.android.contacts.models.Contact
+import chat.rocket.android.db.model.ChatRoomEntity
+import chat.rocket.android.db.model.ContactEntity
+
+@Dao
+abstract class ContactDao : BaseDao<ContactEntity> {
+    @Transaction
+    @Query("""
+        SELECT * FROM contacts
+    """)
+    abstract fun getAllSync(): List<Contact>
+
+    @Query("DELETE FROM contacts")
+    abstract fun delete()
+
+    @Transaction
+    open fun cleanInsert(contacts: List<ContactEntity>) {
+        delete()
+        insert(contacts)
+    }
+}

--- a/app/src/main/java/chat/rocket/android/db/ContactDao.kt
+++ b/app/src/main/java/chat/rocket/android/db/ContactDao.kt
@@ -12,7 +12,7 @@ abstract class ContactDao : BaseDao<ContactEntity> {
     @Query("""
         SELECT * FROM contacts
     """)
-    abstract fun getAllSync(): List<Contact>
+    abstract fun getAllSync(): List<ContactEntity>
 
     @Query("DELETE FROM contacts")
     abstract fun delete()

--- a/app/src/main/java/chat/rocket/android/db/ContactDao.kt
+++ b/app/src/main/java/chat/rocket/android/db/ContactDao.kt
@@ -4,7 +4,6 @@ import androidx.room.Dao
 import androidx.room.Query
 import androidx.room.Transaction
 import chat.rocket.android.contacts.models.Contact
-import chat.rocket.android.db.model.ChatRoomEntity
 import chat.rocket.android.db.model.ContactEntity
 
 @Dao

--- a/app/src/main/java/chat/rocket/android/db/RCDatabase.kt
+++ b/app/src/main/java/chat/rocket/android/db/RCDatabase.kt
@@ -7,6 +7,7 @@ import chat.rocket.android.db.model.AttachmentActionEntity
 import chat.rocket.android.db.model.AttachmentEntity
 import chat.rocket.android.db.model.AttachmentFieldEntity
 import chat.rocket.android.db.model.ChatRoomEntity
+import chat.rocket.android.db.model.ContactEntity
 import chat.rocket.android.db.model.MessageChannels
 import chat.rocket.android.db.model.MessageEntity
 import chat.rocket.android.db.model.MessageFavoritesRelation
@@ -23,9 +24,9 @@ import chat.rocket.android.emoji.internal.db.StringListConverter
         MessageFavoritesRelation::class, MessageMentionsRelation::class,
         MessageChannels::class, AttachmentEntity::class,
         AttachmentFieldEntity::class, AttachmentActionEntity::class, UrlEntity::class,
-        ReactionEntity::class, MessagesSync::class
+        ReactionEntity::class, MessagesSync::class, ContactEntity::class
     ],
-    version = 12,
+    version = 13,
     exportSchema = true
 )
 @TypeConverters(StringListConverter::class)
@@ -33,4 +34,5 @@ abstract class RCDatabase : RoomDatabase() {
     abstract fun userDao(): UserDao
     abstract fun chatRoomDao(): ChatRoomDao
     abstract fun messageDao(): MessageDao
+    abstract fun contactDao(): ContactDao
 }

--- a/app/src/main/java/chat/rocket/android/db/model/Contacts.kt
+++ b/app/src/main/java/chat/rocket/android/db/model/Contacts.kt
@@ -8,7 +8,9 @@ data class ContactEntity(
         @PrimaryKey(autoGenerate = true)
         var id: Int,
         var name: String? = null,
+        var username: String? = null,
         var phoneNumber: String? = null,
         var emailAddress: String? = null,
         var isPhone: Boolean = true
+
 )

--- a/app/src/main/java/chat/rocket/android/db/model/Contacts.kt
+++ b/app/src/main/java/chat/rocket/android/db/model/Contacts.kt
@@ -1,0 +1,14 @@
+package chat.rocket.android.db.model
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "contacts")
+data class ContactEntity(
+        @PrimaryKey(autoGenerate = true)
+        var id: Int,
+        var name: String? = null,
+        var phoneNumber: String? = null,
+        var emailAddress: String? = null,
+        var isPhone: Boolean = true
+)

--- a/app/src/main/java/chat/rocket/android/main/presentation/MainPresenter.kt
+++ b/app/src/main/java/chat/rocket/android/main/presentation/MainPresenter.kt
@@ -44,15 +44,12 @@ import chat.rocket.common.util.ifNull
 import chat.rocket.core.RocketChatClient
 import chat.rocket.core.internal.rest.getCustomEmojis
 import chat.rocket.core.internal.rest.me
-import chat.rocket.core.internal.rest.unregisterPushToken
 import chat.rocket.core.internal.rest.inviteViaEmail
 import chat.rocket.core.internal.rest.inviteViaSMS
 import chat.rocket.core.model.Myself
 import kotlinx.coroutines.experimental.channels.Channel
 import timber.log.Timber
 import javax.inject.Inject
-import chat.rocket.android.util.extensions.showToast
-
 
 class MainPresenter @Inject constructor(
     private val view: MainView,
@@ -343,4 +340,5 @@ class MainPresenter @Inject constructor(
             list.removeAll { it.info.roomId == chatRoomId }
         }
     }
+
 }

--- a/app/src/main/java/chat/rocket/android/util/extensions/RocketChatClient.kt
+++ b/app/src/main/java/chat/rocket/android/util/extensions/RocketChatClient.kt
@@ -1,5 +1,7 @@
 package chat.rocket.android.util.extensions
 
+import chat.rocket.android.contacts.models.Contact
+import chat.rocket.android.db.model.ContactEntity
 import chat.rocket.android.db.model.MessageEntity
 import chat.rocket.android.server.domain.model.Account
 import chat.rocket.android.server.infraestructure.RocketChatClientFactory
@@ -47,5 +49,15 @@ fun Message.toEntity(): MessageEntity {
         pinned = pinned,
         role = role,
         synced = synced
+    )
+}
+
+fun Contact.toEntity(): ContactEntity {
+    return ContactEntity(
+            id=0,
+            name = getName(),
+            phoneNumber = getPhoneNumber(),
+            emailAddress = getEmailAddress(),
+            isPhone = isPhone()
     )
 }

--- a/app/src/main/java/chat/rocket/android/util/extensions/RocketChatClient.kt
+++ b/app/src/main/java/chat/rocket/android/util/extensions/RocketChatClient.kt
@@ -56,6 +56,7 @@ fun Contact.toEntity(): ContactEntity {
     return ContactEntity(
             id=0,
             name = getName(),
+            username = getUsername(),
             phoneNumber = getPhoneNumber(),
             emailAddress = getEmailAddress(),
             isPhone = isPhone()


### PR DESCRIPTION
Sync Contacts in background
Closes #154 
Depends on https://github.com/WideChat/Rocket.Chat.Kotlin.SDK/pull/8

A new table named `Contacts` is added.
This PR implements a background worker named `ContactSyncWorker`, which 
  - fetches the contacts from the Android API for contacts
  - formats & sorts them
  - Calculates strong and weak hashes
  - Makes a call to queryContacts endpoint with the weak hashes
  - Gets the matching hashes form server
  - Calculates Intersection
  - Store the result in `Contacts` table
