### PR TITLE
fix avatar update and WIDECHAT crash

### DIFF
--- a/app/src/main/java/chat/rocket/android/chatrooms/ui/ChatRoomsFragment.kt
+++ b/app/src/main/java/chat/rocket/android/chatrooms/ui/ChatRoomsFragment.kt
@@ -51,7 +51,6 @@ import javax.inject.Inject
 // WIDECHAT
 import android.graphics.Color
 import android.widget.*
-import androidx.core.net.toUri
 import androidx.core.view.isGone
 import chat.rocket.android.authentication.domain.model.DeepLinkInfo
 import chat.rocket.android.chatrooms.adapter.model.RoomUiModel
@@ -63,10 +62,6 @@ import chat.rocket.android.util.extensions.avatarUrl
 import com.facebook.drawee.view.SimpleDraweeView
 import kotlinx.android.synthetic.main.app_bar.*
 import kotlinx.coroutines.experimental.launch
-
-//test
-import com.facebook.drawee.backends.pipeline.Fresco
-
 
 internal const val TAG_CHAT_ROOMS_FRAGMENT = "ChatRoomsFragment"
 
@@ -497,7 +492,6 @@ class ChatRoomsFragment : Fragment(), ChatRoomsView {
                 val serverUrl = serverInteractor.get()
                 val user = userHelper.user()
                 val myAvatarUrl: String? =  serverUrl?.avatarUrl(user?.username ?: "")
-                //Fresco.getImagePipeline().evictFromCache(myAvatarUrl?.toUri())
 
                 profileButton = this?.getCustomView()?.findViewById(R.id.profile_image_avatar)
                 profileButton?.setImageURI(myAvatarUrl)

--- a/app/src/main/java/chat/rocket/android/chatrooms/ui/ChatRoomsFragment.kt
+++ b/app/src/main/java/chat/rocket/android/chatrooms/ui/ChatRoomsFragment.kt
@@ -51,6 +51,7 @@ import javax.inject.Inject
 // WIDECHAT
 import android.graphics.Color
 import android.widget.*
+import androidx.core.net.toUri
 import androidx.core.view.isGone
 import chat.rocket.android.authentication.domain.model.DeepLinkInfo
 import chat.rocket.android.chatrooms.adapter.model.RoomUiModel
@@ -62,6 +63,10 @@ import chat.rocket.android.util.extensions.avatarUrl
 import com.facebook.drawee.view.SimpleDraweeView
 import kotlinx.android.synthetic.main.app_bar.*
 import kotlinx.coroutines.experimental.launch
+
+//test
+import com.facebook.drawee.backends.pipeline.Fresco
+
 
 internal const val TAG_CHAT_ROOMS_FRAGMENT = "ChatRoomsFragment"
 
@@ -492,6 +497,7 @@ class ChatRoomsFragment : Fragment(), ChatRoomsView {
                 val serverUrl = serverInteractor.get()
                 val user = userHelper.user()
                 val myAvatarUrl: String? =  serverUrl?.avatarUrl(user?.username ?: "")
+                //Fresco.getImagePipeline().evictFromCache(myAvatarUrl?.toUri())
 
                 profileButton = this?.getCustomView()?.findViewById(R.id.profile_image_avatar)
                 profileButton?.setImageURI(myAvatarUrl)

--- a/app/src/main/java/chat/rocket/android/main/presentation/MainPresenter.kt
+++ b/app/src/main/java/chat/rocket/android/main/presentation/MainPresenter.kt
@@ -1,7 +1,6 @@
 package chat.rocket.android.main.presentation
 
 import android.content.Context
-import androidx.core.net.toUri
 import chat.rocket.android.authentication.domain.model.DeepLinkInfo
 import chat.rocket.android.core.lifecycle.CancelStrategy
 import chat.rocket.android.db.DatabaseManagerFactory
@@ -29,7 +28,6 @@ import chat.rocket.android.server.infraestructure.RocketChatClientFactory
 import chat.rocket.android.server.presentation.CheckServerPresenter
 import chat.rocket.android.util.extension.launchUI
 import chat.rocket.android.util.extensions.adminPanelUrl
-import chat.rocket.android.util.extensions.avatarUrl
 import chat.rocket.android.util.extensions.serverLogoUrl
 import chat.rocket.android.util.retryIO
 import chat.rocket.common.RocketChatAuthException
@@ -44,8 +42,10 @@ import timber.log.Timber
 import javax.inject.Inject
 
 // WIDECHAT
+import androidx.core.net.toUri
 import com.facebook.drawee.backends.pipeline.Fresco
 import chat.rocket.android.infrastructure.username
+import chat.rocket.android.util.extensions.avatarUrl
 
 class MainPresenter @Inject constructor(
     private val view: MainView,

--- a/app/src/main/java/chat/rocket/android/main/presentation/MainPresenter.kt
+++ b/app/src/main/java/chat/rocket/android/main/presentation/MainPresenter.kt
@@ -1,6 +1,7 @@
 package chat.rocket.android.main.presentation
 
 import android.content.Context
+import androidx.core.net.toUri
 import chat.rocket.android.authentication.domain.model.DeepLinkInfo
 import chat.rocket.android.core.lifecycle.CancelStrategy
 import chat.rocket.android.db.DatabaseManagerFactory
@@ -28,6 +29,7 @@ import chat.rocket.android.server.infraestructure.RocketChatClientFactory
 import chat.rocket.android.server.presentation.CheckServerPresenter
 import chat.rocket.android.util.extension.launchUI
 import chat.rocket.android.util.extensions.adminPanelUrl
+import chat.rocket.android.util.extensions.avatarUrl
 import chat.rocket.android.util.extensions.serverLogoUrl
 import chat.rocket.android.util.retryIO
 import chat.rocket.common.RocketChatAuthException
@@ -40,6 +42,10 @@ import chat.rocket.core.internal.rest.*
 import kotlinx.coroutines.experimental.channels.Channel
 import timber.log.Timber
 import javax.inject.Inject
+
+// WIDECHAT
+import com.facebook.drawee.backends.pipeline.Fresco
+import chat.rocket.android.infrastructure.username
 
 class MainPresenter @Inject constructor(
     private val view: MainView,
@@ -77,6 +83,9 @@ class MainPresenter @Inject constructor(
     private var settings: PublicSettings = getSettingsInteractor.get(serverInteractor.get()!!)
     private val userDataChannel = Channel<Myself>()
 
+    // WIDECHAT
+    private val currentUsername = localRepository.username()
+
     fun toChatList(chatRoomId: String? = null, deepLinkInfo: DeepLinkInfo? = null) = navigator.toChatList(chatRoomId, deepLinkInfo)
 
     fun toUserProfile() = navigator.toUserProfile()
@@ -107,6 +116,11 @@ class MainPresenter @Inject constructor(
                 }
             }
         }
+    }
+
+    fun clearAvatarUrlFromCache() {
+        val myAvatarUrl: String? =  currentServer.avatarUrl(currentUsername ?: "")
+        Fresco.getImagePipeline().evictFromCache(myAvatarUrl?.toUri())
     }
 
     fun loadCurrentInfo() {

--- a/app/src/main/java/chat/rocket/android/main/ui/MainActivity.kt
+++ b/app/src/main/java/chat/rocket/android/main/ui/MainActivity.kt
@@ -54,6 +54,8 @@ import javax.inject.Inject
 // WIDECHAT
 import chat.rocket.android.helper.Constants
 import androidx.core.net.toUri
+//test
+import timber.log.Timber
 
 private const val CURRENT_STATE = "current_state"
 
@@ -81,6 +83,7 @@ class MainActivity : AppCompatActivity(), MainView, HasActivityInjector,
 
         if (Constants.WIDECHAT) {
             setContentView(R.layout.widechat_activity_main)
+            presenter.clearAvatarUrlFromCache()
         } else {
             setContentView(R.layout.activity_main)
         }

--- a/app/src/main/java/chat/rocket/android/main/ui/MainActivity.kt
+++ b/app/src/main/java/chat/rocket/android/main/ui/MainActivity.kt
@@ -81,6 +81,7 @@ class MainActivity : AppCompatActivity(), MainView, HasActivityInjector,
 
         if (Constants.WIDECHAT) {
             setContentView(R.layout.widechat_activity_main)
+            // Loads new avatar when changed on server side
             presenter.clearAvatarUrlFromCache()
         } else {
             setContentView(R.layout.activity_main)

--- a/app/src/main/java/chat/rocket/android/main/ui/MainActivity.kt
+++ b/app/src/main/java/chat/rocket/android/main/ui/MainActivity.kt
@@ -54,8 +54,6 @@ import javax.inject.Inject
 // WIDECHAT
 import chat.rocket.android.helper.Constants
 import androidx.core.net.toUri
-//test
-import timber.log.Timber
 
 private const val CURRENT_STATE = "current_state"
 

--- a/app/src/main/java/chat/rocket/android/profile/presentation/ProfilePresenter.kt
+++ b/app/src/main/java/chat/rocket/android/profile/presentation/ProfilePresenter.kt
@@ -2,7 +2,6 @@ package chat.rocket.android.profile.presentation
 
 import android.graphics.Bitmap
 import android.net.Uri
-import androidx.core.net.toUri
 import chat.rocket.android.chatroom.domain.UriInteractor
 import chat.rocket.android.core.behaviours.showMessage
 import chat.rocket.android.core.lifecycle.CancelStrategy

--- a/app/src/main/java/chat/rocket/android/profile/presentation/ProfilePresenter.kt
+++ b/app/src/main/java/chat/rocket/android/profile/presentation/ProfilePresenter.kt
@@ -2,6 +2,7 @@ package chat.rocket.android.profile.presentation
 
 import android.graphics.Bitmap
 import android.net.Uri
+import androidx.core.net.toUri
 import chat.rocket.android.chatroom.domain.UriInteractor
 import chat.rocket.android.core.behaviours.showMessage
 import chat.rocket.android.core.lifecycle.CancelStrategy
@@ -83,7 +84,7 @@ class ProfilePresenter @Inject constructor(
         }
     }
 
-    // WIDECHAT
+    // WIDECHAT - profile update with SSO
     fun setUpdateUrl(updatePath: String?, onClickCallback: (String?) -> Unit?) {
         launchUI(strategy) {
             try {

--- a/app/src/main/java/chat/rocket/android/profile/ui/ProfileFragment.kt
+++ b/app/src/main/java/chat/rocket/android/profile/ui/ProfileFragment.kt
@@ -125,7 +125,6 @@ class ProfileFragment : Fragment(), ProfileView, ActionMode.Callback {
             image_avatar.setImageURI(avatarUrl)
             widechat_text_username.textContent = username
             widechat_text_email.textContent = email ?: ""
-
             widechat_profile_container.isVisible = true
         }
     }
@@ -173,9 +172,13 @@ class ProfileFragment : Fragment(), ProfileView, ActionMode.Callback {
     }
 
     override fun reloadUserAvatar(avatarUrl: String) {
-        Fresco.getImagePipeline().evictFromCache(avatarUrl.toUri())
+        Fresco.getImagePipeline().clearCaches()
         image_avatar.setImageURI(avatarUrl)
-        (activity as MainActivity).setAvatar(avatarUrl)
+        if (!Constants.WIDECHAT) {
+            (activity as MainActivity).setAvatar(avatarUrl)
+        } else {
+            presenter.loadUserProfile()
+        }
     }
 
     override fun showProfileUpdateSuccessfullyMessage() {

--- a/app/src/main/java/chat/rocket/android/profile/ui/ProfileFragment.kt
+++ b/app/src/main/java/chat/rocket/android/profile/ui/ProfileFragment.kt
@@ -28,12 +28,7 @@ import chat.rocket.android.profile.presentation.ProfileView
 import chat.rocket.android.util.extension.asObservable
 import chat.rocket.android.util.extension.dispatchImageSelection
 import chat.rocket.android.util.extension.dispatchTakePicture
-import chat.rocket.android.util.extensions.inflate
-import chat.rocket.android.util.extensions.showToast
-import chat.rocket.android.util.extensions.textContent
-import chat.rocket.android.util.extensions.ui
 import chat.rocket.android.util.invalidateFirebaseToken
-import com.facebook.drawee.backends.pipeline.Fresco
 import dagger.android.support.AndroidSupportInjection
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.rxkotlin.Observables
@@ -44,7 +39,7 @@ import javax.inject.Inject
 
 // WIDECHAT
 import chat.rocket.android.helper.Constants
-import chat.rocket.android.util.extensions.openTabbedUrl
+import chat.rocket.android.util.extensions.*
 import kotlinx.android.synthetic.main.app_bar.* // need this for back button in setupToolbar
 import kotlinx.android.synthetic.main.fragment_profile_widechat.*
 
@@ -172,7 +167,7 @@ class ProfileFragment : Fragment(), ProfileView, ActionMode.Callback {
     }
 
     override fun reloadUserAvatar(avatarUrl: String) {
-        Fresco.getImagePipeline().clearCaches()
+        (activity as MainActivity).presenter.clearAvatarUrlFromCache()
         image_avatar.setImageURI(avatarUrl)
         if (!Constants.WIDECHAT) {
             (activity as MainActivity).setAvatar(avatarUrl)

--- a/app/src/main/java/chat/rocket/android/profile/ui/ProfileFragment.kt
+++ b/app/src/main/java/chat/rocket/android/profile/ui/ProfileFragment.kt
@@ -28,6 +28,7 @@ import chat.rocket.android.profile.presentation.ProfileView
 import chat.rocket.android.util.extension.asObservable
 import chat.rocket.android.util.extension.dispatchImageSelection
 import chat.rocket.android.util.extension.dispatchTakePicture
+import chat.rocket.android.util.extensions.*
 import chat.rocket.android.util.invalidateFirebaseToken
 import dagger.android.support.AndroidSupportInjection
 import io.reactivex.disposables.CompositeDisposable
@@ -39,7 +40,6 @@ import javax.inject.Inject
 
 // WIDECHAT
 import chat.rocket.android.helper.Constants
-import chat.rocket.android.util.extensions.*
 import kotlinx.android.synthetic.main.app_bar.* // need this for back button in setupToolbar
 import kotlinx.android.synthetic.main.fragment_profile_widechat.*
 


### PR DESCRIPTION
fixes https://github.com/WideChat/Rocket.Chat.Android/issues/213

This now works in two important use cases:
- When the user changes the avatar on the device locally it will automatically repopulate all the avatar images.
- When the user changes the avatar on the server side, the avatar will update, but only when the app is restarted.

Bug:
- When the user logs out, and logs in again as a different user, the avatar update will not show at all until the user closes and reopens the app.  This is because the localRepository is not refreshed in this case, until the app is reloaded.  Since this is kind of an edge case, I recommend that we deal with it later. 