### PR TITLE
close keyboard when moving from chatrooms to contacts

### DIFF
--- a/app/src/main/java/chat/rocket/android/chatrooms/ui/ChatRoomsFragment.kt
+++ b/app/src/main/java/chat/rocket/android/chatrooms/ui/ChatRoomsFragment.kt
@@ -146,6 +146,12 @@ class ChatRoomsFragment : Fragment(), ChatRoomsView {
         super.onResume()
     }
 
+    override fun onPause() {
+        searchView?.clearFocus()
+        searchView?.setQuery("", false)
+        super.onPause()
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,


### PR DESCRIPTION
This fixes a small bug:  If the search view is active on the chatrooms page, and the keyboard is open, if you click the FAB, the keyboard remains open on the contacts page.