### PR TITLE
resume main activity after first use allow access to contacts

### DIFF
--- a/app/src/main/java/chat/rocket/android/main/ui/MainActivity.kt
+++ b/app/src/main/java/chat/rocket/android/main/ui/MainActivity.kt
@@ -393,9 +393,6 @@ class MainActivity : AppCompatActivity(), MainView, HasActivityInjector,
                 // If request is cancelled, the result arrays are empty.
                 if ((grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED)) {
                     syncContacts(false)
-                    // Resume main activity here to refresh the current fragment
-                    val openMainActivity= Intent(this, MainActivity::class.java)
-                    startActivity(openMainActivity)
                 } else if ((grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_DENIED)) {
                     var showRationale: Boolean = shouldShowRequestPermissionRationale(permissions[0])
                     if (!showRationale) {
@@ -403,6 +400,9 @@ class MainActivity : AppCompatActivity(), MainView, HasActivityInjector,
                         contactsPermissionAlertDialog(willNotShowPermissions = true)
                     }
                 }
+                // Resume main activity here to refresh the current fragment
+                val openMainActivity= Intent(this, MainActivity::class.java)
+                startActivity(openMainActivity)
                 return
             }
             else -> {

--- a/app/src/main/java/chat/rocket/android/main/ui/MainActivity.kt
+++ b/app/src/main/java/chat/rocket/android/main/ui/MainActivity.kt
@@ -400,6 +400,8 @@ class MainActivity : AppCompatActivity(), MainView, HasActivityInjector,
                         contactsPermissionAlertDialog(willNotShowPermissions = true)
                     }
                 }
+                val openMainActivity= Intent(this, MainActivity::class.java)
+                startActivity(openMainActivity)
                 return
             }
             else -> {

--- a/app/src/main/java/chat/rocket/android/main/ui/MainActivity.kt
+++ b/app/src/main/java/chat/rocket/android/main/ui/MainActivity.kt
@@ -393,6 +393,9 @@ class MainActivity : AppCompatActivity(), MainView, HasActivityInjector,
                 // If request is cancelled, the result arrays are empty.
                 if ((grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED)) {
                     syncContacts(false)
+                    // Resume main activity here to refresh the current fragment
+                    val openMainActivity= Intent(this, MainActivity::class.java)
+                    startActivity(openMainActivity)
                 } else if ((grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_DENIED)) {
                     var showRationale: Boolean = shouldShowRequestPermissionRationale(permissions[0])
                     if (!showRationale) {
@@ -400,8 +403,6 @@ class MainActivity : AppCompatActivity(), MainView, HasActivityInjector,
                         contactsPermissionAlertDialog(willNotShowPermissions = true)
                     }
                 }
-                val openMainActivity= Intent(this, MainActivity::class.java)
-                startActivity(openMainActivity)
                 return
             }
             else -> {

--- a/app/src/main/java/chat/rocket/android/main/ui/MainActivity.kt
+++ b/app/src/main/java/chat/rocket/android/main/ui/MainActivity.kt
@@ -403,6 +403,7 @@ class MainActivity : AppCompatActivity(), MainView, HasActivityInjector,
                 // Resume main activity here to refresh the current fragment
                 val openMainActivity= Intent(this, MainActivity::class.java)
                 startActivity(openMainActivity)
+                this.finish()
                 return
             }
             else -> {

--- a/app/src/main/java/chat/rocket/android/main/ui/MainActivity.kt
+++ b/app/src/main/java/chat/rocket/android/main/ui/MainActivity.kt
@@ -400,7 +400,7 @@ class MainActivity : AppCompatActivity(), MainView, HasActivityInjector,
                         contactsPermissionAlertDialog(willNotShowPermissions = true)
                     }
                 }
-                // Resume main activity here to refresh the current fragment
+                // Re-open main activity here to refresh the current fragment
                 val openMainActivity= Intent(this, MainActivity::class.java)
                 startActivity(openMainActivity)
                 this.finish()


### PR DESCRIPTION
fixes: https://github.com/WideChat/Rocket.Chat.Android/issues/264 by calling resume() on the main activity after allowing access to contacts. 

PS. This method also has a problem......  after restarting the activity the refresh button on the contacts page no longer works......  still looking.......