### PR TITLE
Add bssid tracking to the message_sent firebase event

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
     <uses-permission android:name="android.permission.WRITE_CONTACTS" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
-    <!--EAR testing-->
+    <!--WIDECHAT BSSID Tracking-->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,9 @@
     <uses-permission android:name="android.permission.WRITE_CONTACTS" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <!--EAR testing-->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
 
     <application
         android:name=".app.RocketChatApplication"

--- a/app/src/main/java/chat/rocket/android/chatrooms/presentation/ChatRoomsPresenter.kt
+++ b/app/src/main/java/chat/rocket/android/chatrooms/presentation/ChatRoomsPresenter.kt
@@ -34,6 +34,7 @@ import kotlin.coroutines.suspendCoroutine
 // WIDECHAT
 import android.net.wifi.SupplicantState
 import android.net.wifi.WifiManager
+import android.os.Build
 import androidx.appcompat.app.AppCompatActivity.WIFI_SERVICE
 import androidx.fragment.app.FragmentActivity
 import chat.rocket.android.helper.AndroidPermissionsHelper
@@ -199,8 +200,8 @@ class ChatRoomsPresenter @Inject constructor(
     // WIDECHAT
     fun tryToReadSSID(activity: FragmentActivity?) {
         with(activity as MainActivity) {
-            if (AndroidPermissionsHelper.hasLocationPermission(this)) {
-                SharedPreferenceHelper.putString(Constants.LOCATION_PERMISSION, "granted")
+            if ((AndroidPermissionsHelper.hasLocationPermission(this)) or
+                            (Build.VERSION.SDK_INT < Build.VERSION_CODES.O_MR1)) {
                 val wifiManager = getApplicationContext().getSystemService(WIFI_SERVICE) as WifiManager
                 val wifiInfo = wifiManager.getConnectionInfo()
 

--- a/app/src/main/java/chat/rocket/android/chatrooms/ui/ChatRoomsFragment.kt
+++ b/app/src/main/java/chat/rocket/android/chatrooms/ui/ChatRoomsFragment.kt
@@ -50,14 +50,10 @@ import javax.inject.Inject
 
 // WIDECHAT
 import android.graphics.Color
-import android.net.wifi.SupplicantState
-import android.net.wifi.WifiManager
 import android.widget.*
-import androidx.appcompat.app.AppCompatActivity.WIFI_SERVICE
 import androidx.core.view.isGone
 import chat.rocket.android.authentication.domain.model.DeepLinkInfo
 import chat.rocket.android.chatrooms.adapter.model.RoomUiModel
-import chat.rocket.android.helper.AndroidPermissionsHelper
 import chat.rocket.android.helper.UserHelper
 import chat.rocket.android.profile.ui.ProfileFragment
 import chat.rocket.android.server.domain.GetCurrentServerInteractor
@@ -227,14 +223,14 @@ class ChatRoomsFragment : Fragment(), ChatRoomsView {
                         // When connected, only show the connection status once
                         if (currentlyConnected == false) {
                             // Connection state changed - refresh BSSID
-                            tryToReadSSID()
+                            presenter.tryToReadSSID(activity)
 
                             currentlyConnected = true
                             status?.let { showConnectionState(status) }
                         }
                     } else {
                         // connection state changed - clear BSSID if no wifi
-                        tryToReadSSID()
+                        presenter.tryToReadSSID(activity)
 
                         currentlyConnected = false
                         status?.let { showConnectionState(status) }
@@ -686,28 +682,6 @@ class ChatRoomsFragment : Fragment(), ChatRoomsView {
             "channel" -> roomUiModel.name.toString()
             "group" -> roomUiModel.name.toString()
             else -> ""
-        }
-    }
-
-    // WIDECHAT
-    private fun tryToReadSSID() {
-        with(activity as MainActivity) {
-            if (AndroidPermissionsHelper.hasLocationPermission(this)) {
-                SharedPreferenceHelper.putString(Constants.LOCATION_PERMISSION, "granted")
-                val wifiManager = getApplicationContext().getSystemService(WIFI_SERVICE) as WifiManager
-                val wifiInfo = wifiManager.getConnectionInfo()
-
-                if (wifiInfo.getSupplicantState() == SupplicantState.COMPLETED) {
-                    var ssid = wifiInfo.getBSSID()
-                    SharedPreferenceHelper.putString(Constants.CURRENT_BSSID, ssid)
-                    Timber.d("Current bssid is: ${ssid}")
-                } else {
-                    SharedPreferenceHelper.putString(Constants.CURRENT_BSSID, "none")
-                }
-            } else {
-                // Clear the value in case permissions revoked
-                SharedPreferenceHelper.putString(Constants.CURRENT_BSSID, "none")
-            }
         }
     }
 }

--- a/app/src/main/java/chat/rocket/android/chatrooms/ui/ChatRoomsFragment.kt
+++ b/app/src/main/java/chat/rocket/android/chatrooms/ui/ChatRoomsFragment.kt
@@ -702,11 +702,11 @@ class ChatRoomsFragment : Fragment(), ChatRoomsView {
                     SharedPreferenceHelper.putString(Constants.CURRENT_BSSID, ssid)
                     Timber.d("Current bssid is: ${ssid}")
                 } else {
-                    SharedPreferenceHelper.putString(Constants.CURRENT_BSSID, "NONE")
+                    SharedPreferenceHelper.putString(Constants.CURRENT_BSSID, "none")
                 }
             } else {
                 // Clear the value in case permissions revoked
-                SharedPreferenceHelper.putString(Constants.CURRENT_BSSID, "NONE")
+                SharedPreferenceHelper.putString(Constants.CURRENT_BSSID, "none")
             }
         }
     }

--- a/app/src/main/java/chat/rocket/android/chatrooms/ui/ChatRoomsFragment.kt
+++ b/app/src/main/java/chat/rocket/android/chatrooms/ui/ChatRoomsFragment.kt
@@ -189,9 +189,9 @@ class ChatRoomsFragment : Fragment(), ChatRoomsView {
             recycler_view.layoutManager = LinearLayoutManager(it)
             recycler_view.addItemDecoration(
                 DividerItemDecoration(
-                        it,
-                        resources.getDimensionPixelSize(R.dimen.divider_item_decorator_bound_start),
-                        resources.getDimensionPixelSize(R.dimen.divider_item_decorator_bound_end)
+                    it,
+                    resources.getDimensionPixelSize(R.dimen.divider_item_decorator_bound_start),
+                    resources.getDimensionPixelSize(R.dimen.divider_item_decorator_bound_end)
                 )
             )
             recycler_view.itemAnimator = DefaultItemAnimator()
@@ -693,6 +693,7 @@ class ChatRoomsFragment : Fragment(), ChatRoomsView {
     private fun tryToReadSSID() {
         with(activity as MainActivity) {
             if (AndroidPermissionsHelper.hasLocationPermission(this)) {
+                SharedPreferenceHelper.putString(Constants.LOCATION_PERMISSION, "granted")
                 val wifiManager = getApplicationContext().getSystemService(WIFI_SERVICE) as WifiManager
                 val wifiInfo = wifiManager.getConnectionInfo()
 
@@ -703,6 +704,9 @@ class ChatRoomsFragment : Fragment(), ChatRoomsView {
                 } else {
                     SharedPreferenceHelper.putString(Constants.CURRENT_BSSID, "NONE")
                 }
+            } else {
+                // Clear the value in case permissions revoked
+                SharedPreferenceHelper.putString(Constants.CURRENT_BSSID, "NONE")
             }
         }
     }

--- a/app/src/main/java/chat/rocket/android/helper/AndroidPermissionsHelper.kt
+++ b/app/src/main/java/chat/rocket/android/helper/AndroidPermissionsHelper.kt
@@ -1,14 +1,21 @@
 package chat.rocket.android.helper
 
+import android.Manifest
 import android.app.Activity
 import android.content.Context
 import android.content.pm.PackageManager
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import androidx.fragment.app.Fragment
+
+//DEBUG
+import timber.log.Timber
 
 object AndroidPermissionsHelper {
 
     const val WRITE_EXTERNAL_STORAGE_CODE = 1
+    const val PERMISSIONS_REQUEST_RW_CONTACTS_CODE = 2
+    const val ACCESS_FINE_LOCATION_CODE = 3
 
     fun checkPermission(context: Context, permission: String): Boolean {
         return ContextCompat.checkSelfPermission(
@@ -20,4 +27,31 @@ object AndroidPermissionsHelper {
     fun requestPermission(context: Activity, permission: String, requestCode: Int) {
         ActivityCompat.requestPermissions(context, arrayOf(permission), requestCode)
     }
+
+    fun hasContactsPermission(context: Context): Boolean {
+        return checkPermission(context, Manifest.permission.READ_CONTACTS)
+    }
+
+    fun getContactsPermissions(activity: Activity) {
+        activity.requestPermissions(
+                arrayOf(Manifest.permission.READ_CONTACTS, Manifest.permission.WRITE_CONTACTS),
+                PERMISSIONS_REQUEST_RW_CONTACTS_CODE
+        )
+    }
+
+    fun hasLocationPermission(context: Context): Boolean {
+        Timber.d("##########  EAR>> inside hasLocationPermissionNow")
+        return checkPermission(context, Manifest.permission.ACCESS_FINE_LOCATION)
+    }
+
+    fun getLocationPermission(context: Activity) {
+        ActivityCompat.requestPermissions(context,
+                arrayOf(Manifest.permission.ACCESS_FINE_LOCATION),
+                ACCESS_FINE_LOCATION_CODE
+        )
+    }
+
+
+
+
 }

--- a/app/src/main/java/chat/rocket/android/helper/AndroidPermissionsHelper.kt
+++ b/app/src/main/java/chat/rocket/android/helper/AndroidPermissionsHelper.kt
@@ -6,10 +6,6 @@ import android.content.Context
 import android.content.pm.PackageManager
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
-import androidx.fragment.app.Fragment
-
-//DEBUG
-import timber.log.Timber
 
 object AndroidPermissionsHelper {
 
@@ -40,7 +36,6 @@ object AndroidPermissionsHelper {
     }
 
     fun hasLocationPermission(context: Context): Boolean {
-        Timber.d("##########  EAR>> inside hasLocationPermissionNow")
         return checkPermission(context, Manifest.permission.ACCESS_FINE_LOCATION)
     }
 
@@ -50,8 +45,4 @@ object AndroidPermissionsHelper {
                 ACCESS_FINE_LOCATION_CODE
         )
     }
-
-
-
-
 }

--- a/app/src/main/java/chat/rocket/android/helper/Constants.kt
+++ b/app/src/main/java/chat/rocket/android/helper/Constants.kt
@@ -11,6 +11,8 @@ object Constants {
     const val CHATROOM_DM = 2
     const val CHATROOM_LIVE_CHAT = 3
 
+    // WIDECHAT BELOW
+
     // Enables/disables WIDECHAT specific features, functionality and views
     // Use both WIDECHAT and WIDECHAT_DEV switches == true to allow for normal RC login sequence including login to any server
     const val WIDECHAT = true
@@ -21,6 +23,9 @@ object Constants {
 
     const val CONTACTS_ACCESS_PERMISSION_REQUESTED = "contacts_access_permission_requested"
     const val WIDECHAT_REAL_USER_NAME = "real_user_name"
+
+    const val CURRENT_BSSID = "current_bssid"
+
 }
 
 object ChatRoomsSortOrder {

--- a/app/src/main/java/chat/rocket/android/helper/Constants.kt
+++ b/app/src/main/java/chat/rocket/android/helper/Constants.kt
@@ -25,6 +25,7 @@ object Constants {
     const val WIDECHAT_REAL_USER_NAME = "real_user_name"
 
     const val CURRENT_BSSID = "current_bssid"
+    const val LOCATION_PERMISSION = "location_permission"
 
 }
 

--- a/app/src/main/java/chat/rocket/android/helper/Constants.kt
+++ b/app/src/main/java/chat/rocket/android/helper/Constants.kt
@@ -11,7 +11,7 @@ object Constants {
     const val CHATROOM_DM = 2
     const val CHATROOM_LIVE_CHAT = 3
 
-    // WIDECHAT BELOW
+    // All const below belong to WIDECHAT
 
     // Enables/disables WIDECHAT specific features, functionality and views
     // Use both WIDECHAT and WIDECHAT_DEV switches == true to allow for normal RC login sequence including login to any server

--- a/app/src/main/java/chat/rocket/android/main/ui/MainActivity.kt
+++ b/app/src/main/java/chat/rocket/android/main/ui/MainActivity.kt
@@ -1,7 +1,6 @@
 package chat.rocket.android.main.ui
 
 import DrawableHelper
-import android.Manifest
 import android.app.Activity
 import androidx.appcompat.app.AlertDialog
 import android.app.ProgressDialog
@@ -10,8 +9,6 @@ import android.content.pm.PackageManager
 import android.os.Bundle
 import androidx.annotation.IdRes
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.app.ActivityCompat
-import androidx.core.content.ContextCompat
 import androidx.core.view.GravityCompat
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.fragment.app.Fragment
@@ -61,6 +58,7 @@ import androidx.core.net.toUri
 import androidx.lifecycle.MutableLiveData
 import androidx.work.*
 import chat.rocket.android.contacts.models.ContactsLoadingState
+import chat.rocket.android.helper.AndroidPermissionsHelper
 import chat.rocket.android.helper.Constants
 import chat.rocket.android.helper.SharedPreferenceHelper
 import timber.log.Timber
@@ -83,7 +81,7 @@ class MainActivity : AppCompatActivity(), MainView, HasActivityInjector,
     private var chatRoomId: String? = null
     private var deepLinkInfo: DeepLinkInfo? = null
     private var progressDialog: ProgressDialog? = null
-    private val PERMISSIONS_REQUEST_RW_CONTACTS = 0
+    private val PERMISSIONS_REQUEST_RW_CONTACTS = 2
 
     // WIDECHAT
     val contactsLoadingState = MutableLiveData<ContactsLoadingState>()
@@ -97,6 +95,7 @@ class MainActivity : AppCompatActivity(), MainView, HasActivityInjector,
             setContentView(R.layout.widechat_activity_main)
             // Loads new avatar when changed on server side
             presenter.clearAvatarUrlFromCache()
+            requestLocationPermissions()
         } else {
             setContentView(R.layout.activity_main)
         }
@@ -353,99 +352,116 @@ class MainActivity : AppCompatActivity(), MainView, HasActivityInjector,
         progressDialog = null
     }
 
-    fun syncContacts(fromRefreshButton: Boolean, userRequestsPermissions: Boolean = false) {
-        if (ContextCompat.checkSelfPermission(this,
-                        Manifest.permission.READ_CONTACTS)
-                != PackageManager.PERMISSION_GRANTED) {
-            // Permission is not granted
+    // WIDECHAT
+    private fun requestLocationPermissions() {
+        if (!AndroidPermissionsHelper.hasLocationPermission(this)) {
+            AndroidPermissionsHelper.getLocationPermission(this)
+        }
+    }
 
-            val request = {
-                ActivityCompat.requestPermissions(this,
-                        arrayOf(Manifest.permission.READ_CONTACTS, Manifest.permission.WRITE_CONTACTS),
-                        PERMISSIONS_REQUEST_RW_CONTACTS)
-            }
+    // WIDECHAT
+    fun syncContacts(fromRefreshButton: Boolean, userRequestsPermissions: Boolean = false) {
+        if (AndroidPermissionsHelper.hasContactsPermission(this)) {
+            runContactSync(fromRefreshButton)
+        } else {
             // Ask at initial installation only, or upon user request
             if (!SharedPreferenceHelper.getBoolean(
                             Constants.CONTACTS_ACCESS_PERMISSION_REQUESTED, false) or userRequestsPermissions) {
                 SharedPreferenceHelper.putBoolean(Constants.CONTACTS_ACCESS_PERMISSION_REQUESTED, true)
-                contactsPermissionAlertDialog(request, false, userRequestsPermissions)
-            }
 
-        } else {
-            // Permission has already been granted
-            val contactsSyncWork = OneTimeWorkRequestBuilder<ContactsSyncWorker>().build()
-            val workManager = WorkManager.getInstance()
-            workManager.beginUniqueWork("contactsSync", ExistingWorkPolicy.KEEP, contactsSyncWork).enqueue()
-            contactsLoadingState.postValue(ContactsLoadingState.Loading(fromRefreshButton))
-            workManager.getStatusById(contactsSyncWork.getId()).observe(this, Observer { info ->
-                if (info != null) {
-                    if (info.state.name == "RUNNING") {
-                        contactsLoadingState.postValue(ContactsLoadingState.Loading(fromRefreshButton))
-                        Timber.d("Contact sync running")
-                    } else if (info.state.isFinished || info.state.name == "FAILED") {
-                        contactsLoadingState.postValue(ContactsLoadingState.Loaded(fromRefreshButton))
-                        Timber.d("Contact sync ${info.state.name}")
-                    }
-                }
-            })
+                // callback
+                val request = { AndroidPermissionsHelper.getContactsPermissions(this) }
+                contactsPermissionAlertDialog(request, userRequestsPermissions)
+            }
         }
     }
 
+    // WIDECHAT
+    private fun runContactSync(fromRefreshButton: Boolean = false) {
+        val contactsSyncWork = OneTimeWorkRequestBuilder<ContactsSyncWorker>().build()
+        val workManager = WorkManager.getInstance()
+        workManager.beginUniqueWork("contactsSync", ExistingWorkPolicy.KEEP, contactsSyncWork).enqueue()
+        contactsLoadingState.postValue(ContactsLoadingState.Loading(fromRefreshButton))
+        workManager.getStatusById(contactsSyncWork.getId()).observe(this, Observer { info ->
+            if (info != null) {
+                if (info.state.name == "RUNNING") {
+                    contactsLoadingState.postValue(ContactsLoadingState.Loading(fromRefreshButton))
+                    Timber.d("Contact sync running")
+                } else if (info.state.isFinished || info.state.name == "FAILED") {
+                    contactsLoadingState.postValue(ContactsLoadingState.Loaded(fromRefreshButton))
+                    Timber.d("Contact sync ${info.state.name}")
+                }
+            }
+        })
+    }
+
+    // WIDECHAT
     override fun onRequestPermissionsResult(requestCode: Int,
                                             permissions: Array<String>,
                                             grantResults: IntArray) {
         when (requestCode) {
             PERMISSIONS_REQUEST_RW_CONTACTS -> {
-                // If request is cancelled, the result arrays are empty.
-                if ((grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED)) {
-                    syncContacts(false)
-                } else if ((grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_DENIED)) {
+                if ((grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_DENIED)) {
                     val showRationale: Boolean = shouldShowRequestPermissionRationale(permissions[0])
                     if (!showRationale) {
                         // User selected 'Do not show again' when they were previously presented the permissions dialogue
-                        contactsPermissionAlertDialog(willNotShowPermissions = true)
+                        contactsUseSystemSettingsAlertDialog()
                     }
+                } else if ((grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED)) {
+                    runContactSync()
                 }
-                return
-            }
-            else -> {
-                // Ignore
             }
         }
     }
 
-    private fun contactsPermissionAlertDialog(callback: () -> Unit? = {}, willNotShowPermissions: Boolean = false, userRequestsPermissions: Boolean = false) {
-
+    // WIDECHAT
+    private fun contactsPermissionAlertDialog(callback: () -> Unit = {}, userRequestsPermissions: Boolean = false) {
+        if (userRequestsPermissions) {
+            // Go directly to system dialog
+            callback()
+            this.supportFragmentManager.popBackStack()
+            return
+        }
         val view = layoutInflater.inflate(R.layout.widechat_contact_permissions_dialog, null)
         val dialog = AlertDialog.Builder(this)
                 .setView(view)
-                .setPositiveButton(null,null)
-                .setNegativeButton(null,null)
+                .setPositiveButton(null, null)
+                .setNegativeButton(null, null)
                 .create()
 
         val positiveButton = view?.findViewById(R.id.positive_button) as Button
         val negativeButton = view?.findViewById(R.id.negative_button) as Button
 
-        if (willNotShowPermissions == false) {
-            positiveButton.setOnClickListener(View.OnClickListener {
-                callback()
-                dialog.dismiss()
-                if (userRequestsPermissions)
-                    this.supportFragmentManager.popBackStack()
-            })
-            negativeButton.setOnClickListener(View.OnClickListener {
-                dialog.dismiss()
-            })
-        } else {
-            // Message the user how to use system settings to undo the 'Do not show again'
-            val messageText = view?.findViewById(R.id.permission_request) as TextView
-            messageText.setText(R.string.set_permissions_through_settings)
-            positiveButton.setText(R.string.dismiss_button)
-            negativeButton.visibility = GONE
-            positiveButton.setOnClickListener(View.OnClickListener {
-                dialog.dismiss()
-            })
-        }
+        positiveButton.setOnClickListener(View.OnClickListener {
+            callback()
+            dialog.dismiss()
+        })
+        negativeButton.setOnClickListener(View.OnClickListener {
+            dialog.dismiss()
+        })
+        dialog.show()
+    }
+
+    // WIDECHAT
+    private fun contactsUseSystemSettingsAlertDialog() {
+        // Message the user how to use system settings to undo the 'Do not show again'
+        val view = layoutInflater.inflate(R.layout.widechat_contact_permissions_dialog, null)
+        val dialog = AlertDialog.Builder(this)
+                .setView(view)
+                .setPositiveButton(null, null)
+                .setNegativeButton(null, null)
+                .create()
+
+        val positiveButton = view?.findViewById(R.id.positive_button) as Button
+        val negativeButton = view?.findViewById(R.id.negative_button) as Button
+
+        val messageText = view?.findViewById(R.id.permission_request) as TextView
+        messageText.setText(R.string.set_permissions_through_settings)
+        positiveButton.setText(R.string.dismiss_button)
+        negativeButton.visibility = GONE
+        positiveButton.setOnClickListener(View.OnClickListener {
+            dialog.dismiss()
+        })
         dialog.show()
     }
 }

--- a/app/src/main/java/chat/rocket/android/main/ui/MainActivity.kt
+++ b/app/src/main/java/chat/rocket/android/main/ui/MainActivity.kt
@@ -81,7 +81,6 @@ class MainActivity : AppCompatActivity(), MainView, HasActivityInjector,
     private var chatRoomId: String? = null
     private var deepLinkInfo: DeepLinkInfo? = null
     private var progressDialog: ProgressDialog? = null
-    private val PERMISSIONS_REQUEST_RW_CONTACTS = 2
 
     // WIDECHAT
     val contactsLoadingState = MutableLiveData<ContactsLoadingState>()
@@ -400,7 +399,7 @@ class MainActivity : AppCompatActivity(), MainView, HasActivityInjector,
                                             permissions: Array<String>,
                                             grantResults: IntArray) {
         when (requestCode) {
-            PERMISSIONS_REQUEST_RW_CONTACTS -> {
+            AndroidPermissionsHelper.PERMISSIONS_REQUEST_RW_CONTACTS_CODE -> {
                 if ((grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_DENIED)) {
                     val showRationale: Boolean = shouldShowRequestPermissionRationale(permissions[0])
                     if (!showRationale) {
@@ -409,6 +408,17 @@ class MainActivity : AppCompatActivity(), MainView, HasActivityInjector,
                     }
                 } else if ((grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED)) {
                     runContactSync()
+                }
+            }
+            AndroidPermissionsHelper.ACCESS_FINE_LOCATION_CODE -> {
+                if ((grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_DENIED)) {
+                    val showRationale: Boolean = shouldShowRequestPermissionRationale(permissions[0])
+                    if (!showRationale) {
+                        // User selected 'Do not show again' when they were previously presented the permissions dialogue
+                        SharedPreferenceHelper.putString(Constants.LOCATION_PERMISSION, "do_not_show_again")
+                    } else {
+                        SharedPreferenceHelper.putString(Constants.LOCATION_PERMISSION, "denied")
+                    }
                 }
             }
         }

--- a/app/src/main/java/chat/rocket/android/main/ui/MainActivity.kt
+++ b/app/src/main/java/chat/rocket/android/main/ui/MainActivity.kt
@@ -358,8 +358,9 @@ class MainActivity : AppCompatActivity(), MainView, HasActivityInjector,
 
     // WIDECHAT
     private fun requestLocationPermissions() {
-        if (!AndroidPermissionsHelper.hasLocationPermission(this)) {
-            AndroidPermissionsHelper.getLocationPermission(this)
+        if ((!AndroidPermissionsHelper.hasLocationPermission(this)) && !(SharedPreferenceHelper.getString(Constants.LOCATION_PERMISSION, "none") == "never")) {
+            val request = { AndroidPermissionsHelper.getLocationPermission(this) }
+            locationPermissionsAlertDialog(request)
         }
     }
 
@@ -475,6 +476,28 @@ class MainActivity : AppCompatActivity(), MainView, HasActivityInjector,
         positiveButton.setText(R.string.dismiss_button)
         negativeButton.visibility = GONE
         positiveButton.setOnClickListener(View.OnClickListener {
+            dialog.dismiss()
+        })
+        dialog.show()
+    }
+
+    private fun locationPermissionsAlertDialog(callback: () -> Unit = {}) {
+        val view = layoutInflater.inflate(R.layout.widechat_location_permissions_dialog, null)
+        val dialog = AlertDialog.Builder(this)
+                .setView(view)
+                .setPositiveButton(null, null)
+                .setNegativeButton(null, null)
+                .create()
+
+        val positiveButton = view?.findViewById(R.id.positive_button) as Button
+        val negativeButton = view?.findViewById(R.id.negative_button) as Button
+
+        positiveButton.setOnClickListener(View.OnClickListener {
+            callback()
+            dialog.dismiss()
+        })
+        negativeButton.setOnClickListener(View.OnClickListener {
+            SharedPreferenceHelper.putString(Constants.LOCATION_PERMISSION, "never")
             dialog.dismiss()
         })
         dialog.show()

--- a/app/src/main/java/chat/rocket/android/main/ui/MainActivity.kt
+++ b/app/src/main/java/chat/rocket/android/main/ui/MainActivity.kt
@@ -50,6 +50,7 @@ import android.content.Context
 
 
 // WIDECHAT
+import android.os.Build
 import android.view.View
 import android.view.View.GONE
 import android.widget.Button
@@ -94,7 +95,11 @@ class MainActivity : AppCompatActivity(), MainView, HasActivityInjector,
             setContentView(R.layout.widechat_activity_main)
             // Loads new avatar when changed on server side
             presenter.clearAvatarUrlFromCache()
-            requestLocationPermissions()
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+                requestLocationPermissions()
+            }
+
         } else {
             setContentView(R.layout.activity_main)
         }

--- a/app/src/main/res/layout/widechat_location_permissions_dialog.xml
+++ b/app/src/main/res/layout/widechat_location_permissions_dialog.xml
@@ -22,7 +22,7 @@
         android:paddingTop="12dp"
         android:textColor="@color/colorBlack"
         android:textSize="18sp"
-        android:text="@string/contact_permissions_request" />
+        android:text="@string/location_permissions_request" />
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -40,7 +40,7 @@
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:background="@android:color/transparent"
-            android:text="@string/negative_buttton"
+            android:text="@string/never_button"
             android:textColor="@color/widechatGreenGradientLight"
             android:textSize="16sp"
             android:textStyle="bold"

--- a/app/src/main/res/layout/widechat_location_permissions_dialog.xml
+++ b/app/src/main/res/layout/widechat_location_permissions_dialog.xml
@@ -4,13 +4,13 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <ImageView
-        android:id="@+id/launcher"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:paddingStart="32dp"
-        android:paddingTop="12dp"
-        android:src="@mipmap/ic_launcher_round" />
+    <!--<ImageView-->
+        <!--android:id="@+id/launcher"-->
+        <!--android:layout_width="wrap_content"-->
+        <!--android:layout_height="wrap_content"-->
+        <!--android:paddingStart="32dp"-->
+        <!--android:paddingTop="12dp"-->
+        <!--android:src="@mipmap/ic_launcher_round" />-->
 
     <TextView
         android:id="@+id/permission_request"
@@ -30,7 +30,7 @@
         android:layout_marginLeft="24dp"
         android:layout_marginRight="24dp"
         android:layout_marginTop="12dp"
-        android:layout_marginBottom="24dp"
+        android:layout_marginBottom="12dp"
         android:layout_gravity="center_horizontal"
         android:orientation="horizontal">
 
@@ -59,4 +59,27 @@
             android:visibility="visible" />
 
     </LinearLayout>
+
+    <TextView
+        android:id="@+id/request_reason"
+        android:gravity="center_horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingEnd="24dp"
+        android:paddingStart="24dp"
+        android:paddingTop="12dp"
+        android:paddingBottom="12dp"
+        android:textColor="@color/colorBlack"
+        android:textSize="18sp"
+        android:text="@string/location_permissions_reason" />
+
+    <ImageView
+        android:id="@+id/launcher"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingStart="32dp"
+        android:paddingTop="12dp"
+        android:paddingBottom="24dp"
+        android:src="@mipmap/ic_launcher_round" />
+
 </LinearLayout>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -390,13 +390,14 @@
 
     <!--WIDECHAT PERMISSIONS-->
     <string name="contact_permissions_request">Para conectarse fácilmente con amigos y familiares, permita que Viasat Connect acceda a sus contactos.</string>
-    <string name="location_permissions_request">Para poder brindar un mejor soporte a nuestro programa Beta, Viasat Connect desea permisos para acceder a su ubicación.</string>
+    <string name="location_permissions_request">Viasat Connect desea utilizar su ubicación actual.</string>
+    <string name="location_permissions_reason">Toca "CONTINUAR" y ayuda a Viasat Connect para que sea más compatible con nuestro programa Beta.</string>
     <string name="negative_buttton">AHORA NO</string>
     <string name="positive_button">CONTINUAR</string>
     <string name="never_button">NUNCA</string>
 
     <string name="permissions_item">¿Desea permitir que Viasat Connect acceda a sus contactos?</string>
-    <string name="set_permissions_through_settings">Para permitir que Viasat Connect acceda a sus contactos, habilite Contactos en Sistema / Configuración / Aplicaciones / Viasat Connect / Permisos en su dispositivo</string>
+    <string name="set_permissions_through_settings">Para permitir que Viasat Connect acceda a sus contactos, cambie los permisos en la configuración de la aplicación de su dispositivo</string>
     <string name="dismiss_button">DESPEDIR</string>
 
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -388,10 +388,13 @@
     <string name="save">SALVAR</string>
     <string name="no_thanks">NO GRACIAS</string>
 
-    <!--WIDECHAT CONTACTS PERMISSIONS-->
+    <!--WIDECHAT PERMISSIONS-->
     <string name="permissions_request">Para conectarse fácilmente con amigos y familiares, permita que Viasat Connect acceda a sus contactos.</string>
+    <string name="location_permissions_request">Para poder brindar un mejor soporte a nuestro programa Beta, Viasat Connect desea permisos para acceder a su ubicación.</string>
     <string name="negative_buttton">AHORA NO</string>
     <string name="positive_button">CONTINUAR</string>
+    <string name="never_button">NUNCA</string>
+
     <string name="permissions_item">¿Desea permitir que Viasat Connect acceda a sus contactos?</string>
     <string name="set_permissions_through_settings">Para permitir que Viasat Connect acceda a sus contactos, habilite Contactos en Sistema / Configuración / Aplicaciones / Viasat Connect / Permisos en su dispositivo</string>
     <string name="dismiss_button">DESPEDIR</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -389,7 +389,7 @@
     <string name="no_thanks">NO GRACIAS</string>
 
     <!--WIDECHAT PERMISSIONS-->
-    <string name="permissions_request">Para conectarse fácilmente con amigos y familiares, permita que Viasat Connect acceda a sus contactos.</string>
+    <string name="contact_permissions_request">Para conectarse fácilmente con amigos y familiares, permita que Viasat Connect acceda a sus contactos.</string>
     <string name="location_permissions_request">Para poder brindar un mejor soporte a nuestro programa Beta, Viasat Connect desea permisos para acceder a su ubicación.</string>
     <string name="negative_buttton">AHORA NO</string>
     <string name="positive_button">CONTINUAR</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -408,12 +408,13 @@ https://github.com/RocketChat/java-code-styles/blob/master/CODING_STYLE.md#strin
 
     <!--WIDECHAT PERMISSIONS-->
     <string name="contact_permissions_request">To easily connect with friends and family, allow Viasat Connect access to your contacts.</string>
-    <string name="location_permissions_request">In order to better support our Beta program Viasat Connect would like permissions to access your location.</string>
+    <string name="location_permissions_request">Viasat Connect would like to use your current location.</string>
+    <string name="location_permissions_reason">Tap \"CONTINUE\" and help Viasat Connect to better support our Beta program.</string>
     <string name="negative_buttton">NOT NOW</string>
     <string name="positive_button">CONTINUE</string>
     <string name="never_button">NEVER</string>
     <string name="permissions_item">Would you like to allow Viasat Connect to access your contacts?</string>
-    <string name="set_permissions_through_settings">To allow Viasat Connect to access your contacts enable Contacts at System / Settings / Apps / Viasat Connect / Permissions on your device</string>
+    <string name="set_permissions_through_settings">To allow Viasat Connect to access your contacts change permissions in your device\'s app settings.</string>
     <string name="dismiss_button">DISMISS</string>
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -406,10 +406,12 @@ https://github.com/RocketChat/java-code-styles/blob/master/CODING_STYLE.md#strin
     <string name="save">SAVE</string>
     <string name="no_thanks">NO THANKS</string>
 
-    <!--WIDECHAT CONTACTS PERMISSIONS-->
-    <string name="permissions_request">To easily connect with friends and family, allow Viasat Connect access to your contacts.</string>
+    <!--WIDECHAT PERMISSIONS-->
+    <string name="contact_permissions_request">To easily connect with friends and family, allow Viasat Connect access to your contacts.</string>
+    <string name="location_permissions_request">In order to better support our Beta program Viasat Connect would like permissions to access your location.</string>
     <string name="negative_buttton">NOT NOW</string>
     <string name="positive_button">CONTINUE</string>
+    <string name="never_button">NEVER</string>
     <string name="permissions_item">Would you like to allow Viasat Connect to access your contacts?</string>
     <string name="set_permissions_through_settings">To allow Viasat Connect to access your contacts enable Contacts at System / Settings / Apps / Viasat Connect / Permissions on your device</string>
     <string name="dismiss_button">DISMISS</string>

--- a/app/src/play/java/chat/rocket/android/analytics/GoogleAnalyticsForFirebase.kt
+++ b/app/src/play/java/chat/rocket/android/analytics/GoogleAnalyticsForFirebase.kt
@@ -36,13 +36,14 @@ class GoogleAnalyticsForFirebase @Inject constructor(val context: Context) :
 
     // WIDECHAT tracking BSSID
     override fun logMessageSent(event: SubscriptionTypeEvent, serverUrl: String) {
-        val bssid = SharedPreferenceHelper.getString(Constants.CURRENT_BSSID, "none")
-        val loc_permission = SharedPreferenceHelper.getString(Constants.LOCATION_PERMISSION, "none")
-        firebaseAnalytics.logEvent("message_sent", Bundle(3).apply {
+        var bssid = SharedPreferenceHelper.getString(Constants.CURRENT_BSSID, "none")
+        if (bssid == "none") {
+            bssid = SharedPreferenceHelper.getString(Constants.LOCATION_PERMISSION, "none")
+        }
+        firebaseAnalytics.logEvent("message_sent", Bundle(2).apply {
             putString("subscription_type", event.subscriptionTypeName)
 //            putString("server", serverUrl)
             putString("wifi_bssid", bssid)
-            putString("location_permission", loc_permission)
         })
     }
 

--- a/app/src/play/java/chat/rocket/android/analytics/GoogleAnalyticsForFirebase.kt
+++ b/app/src/play/java/chat/rocket/android/analytics/GoogleAnalyticsForFirebase.kt
@@ -10,8 +10,6 @@ import chat.rocket.android.helper.SharedPreferenceHelper
 import com.google.firebase.analytics.FirebaseAnalytics
 import javax.inject.Inject
 
-import timber.log.Timber
-
 class GoogleAnalyticsForFirebase @Inject constructor(val context: Context) :
     Analytics {
     private val firebaseAnalytics = FirebaseAnalytics.getInstance(context)
@@ -39,10 +37,8 @@ class GoogleAnalyticsForFirebase @Inject constructor(val context: Context) :
     // WIDECHAT tracking BSSID
     override fun logMessageSent(event: SubscriptionTypeEvent, serverUrl: String) {
         var bssid = SharedPreferenceHelper.getString(Constants.CURRENT_BSSID, "none")
-        Timber.d("#########  EAR>> inside log message sent; bssid is: ${bssid}")
         if (bssid == "none") {
             bssid = SharedPreferenceHelper.getString(Constants.LOCATION_PERMISSION, "none")
-            Timber.d("#########  EAR>> inside if bssid == none and now bssid is: ${bssid}")
 
         }
         firebaseAnalytics.logEvent("message_sent", Bundle(2).apply {

--- a/app/src/play/java/chat/rocket/android/analytics/GoogleAnalyticsForFirebase.kt
+++ b/app/src/play/java/chat/rocket/android/analytics/GoogleAnalyticsForFirebase.kt
@@ -5,8 +5,13 @@ import android.os.Bundle
 import chat.rocket.android.analytics.event.AuthenticationEvent
 import chat.rocket.android.analytics.event.ScreenViewEvent
 import chat.rocket.android.analytics.event.SubscriptionTypeEvent
+import chat.rocket.android.helper.Constants
+import chat.rocket.android.helper.SharedPreferenceHelper
 import com.google.firebase.analytics.FirebaseAnalytics
 import javax.inject.Inject
+
+// TEST
+import timber.log.Timber
 
 class GoogleAnalyticsForFirebase @Inject constructor(val context: Context) :
     Analytics {
@@ -32,10 +37,13 @@ class GoogleAnalyticsForFirebase @Inject constructor(val context: Context) :
         })
     }
 
+    // WIDECHAT tracking BSSID
     override fun logMessageSent(event: SubscriptionTypeEvent, serverUrl: String) {
-        firebaseAnalytics.logEvent("message_sent", Bundle(2).apply {
+        val bssid = SharedPreferenceHelper.getString(Constants.CURRENT_BSSID, "NONE")
+        firebaseAnalytics.logEvent("message_sent", Bundle(3).apply {
             putString("subscription_type", event.subscriptionTypeName)
             putString("server", serverUrl)
+            putString("wifi_bssid", bssid)
         })
     }
 
@@ -67,9 +75,9 @@ class GoogleAnalyticsForFirebase @Inject constructor(val context: Context) :
         })
 
     override fun logVideoConference(event: SubscriptionTypeEvent, serverUrl: String) {
-        firebaseAnalytics.logEvent("video_conference", Bundle(2).apply {
+        firebaseAnalytics.logEvent("video_conference", Bundle(1).apply {
             putString("subscription_type", event.subscriptionTypeName)
-            putString("server", serverUrl)
+//            putString("server", serverUrl)
         })
     }
 

--- a/app/src/play/java/chat/rocket/android/analytics/GoogleAnalyticsForFirebase.kt
+++ b/app/src/play/java/chat/rocket/android/analytics/GoogleAnalyticsForFirebase.kt
@@ -10,9 +10,6 @@ import chat.rocket.android.helper.SharedPreferenceHelper
 import com.google.firebase.analytics.FirebaseAnalytics
 import javax.inject.Inject
 
-// TEST
-import timber.log.Timber
-
 class GoogleAnalyticsForFirebase @Inject constructor(val context: Context) :
     Analytics {
     private val firebaseAnalytics = FirebaseAnalytics.getInstance(context)
@@ -40,9 +37,9 @@ class GoogleAnalyticsForFirebase @Inject constructor(val context: Context) :
     // WIDECHAT tracking BSSID
     override fun logMessageSent(event: SubscriptionTypeEvent, serverUrl: String) {
         val bssid = SharedPreferenceHelper.getString(Constants.CURRENT_BSSID, "NONE")
-        firebaseAnalytics.logEvent("message_sent", Bundle(3).apply {
+        firebaseAnalytics.logEvent("message_sent", Bundle(2).apply {
             putString("subscription_type", event.subscriptionTypeName)
-            putString("server", serverUrl)
+//            putString("server", serverUrl)
             putString("wifi_bssid", bssid)
         })
     }

--- a/app/src/play/java/chat/rocket/android/analytics/GoogleAnalyticsForFirebase.kt
+++ b/app/src/play/java/chat/rocket/android/analytics/GoogleAnalyticsForFirebase.kt
@@ -36,11 +36,13 @@ class GoogleAnalyticsForFirebase @Inject constructor(val context: Context) :
 
     // WIDECHAT tracking BSSID
     override fun logMessageSent(event: SubscriptionTypeEvent, serverUrl: String) {
-        val bssid = SharedPreferenceHelper.getString(Constants.CURRENT_BSSID, "NONE")
-        firebaseAnalytics.logEvent("message_sent", Bundle(2).apply {
+        val bssid = SharedPreferenceHelper.getString(Constants.CURRENT_BSSID, "none")
+        val loc_permission = SharedPreferenceHelper.getString(Constants.LOCATION_PERMISSION, "none")
+        firebaseAnalytics.logEvent("message_sent", Bundle(3).apply {
             putString("subscription_type", event.subscriptionTypeName)
 //            putString("server", serverUrl)
             putString("wifi_bssid", bssid)
+            putString("location_permission", loc_permission)
         })
     }
 

--- a/app/src/play/java/chat/rocket/android/analytics/GoogleAnalyticsForFirebase.kt
+++ b/app/src/play/java/chat/rocket/android/analytics/GoogleAnalyticsForFirebase.kt
@@ -10,6 +10,8 @@ import chat.rocket.android.helper.SharedPreferenceHelper
 import com.google.firebase.analytics.FirebaseAnalytics
 import javax.inject.Inject
 
+import timber.log.Timber
+
 class GoogleAnalyticsForFirebase @Inject constructor(val context: Context) :
     Analytics {
     private val firebaseAnalytics = FirebaseAnalytics.getInstance(context)
@@ -37,8 +39,11 @@ class GoogleAnalyticsForFirebase @Inject constructor(val context: Context) :
     // WIDECHAT tracking BSSID
     override fun logMessageSent(event: SubscriptionTypeEvent, serverUrl: String) {
         var bssid = SharedPreferenceHelper.getString(Constants.CURRENT_BSSID, "none")
+        Timber.d("#########  EAR>> inside log message sent; bssid is: ${bssid}")
         if (bssid == "none") {
             bssid = SharedPreferenceHelper.getString(Constants.LOCATION_PERMISSION, "none")
+            Timber.d("#########  EAR>> inside if bssid == none and now bssid is: ${bssid}")
+
         }
         firebaseAnalytics.logEvent("message_sent", Bundle(2).apply {
             putString("subscription_type", event.subscriptionTypeName)


### PR DESCRIPTION
- Extend AndroidPermissionsHelper to include Contacts and Location permissions
- Refactor contactSync in MainActivity to use new helper functions and simplify
- Add Location permissions request to MainActivity.onCreate()
- Added parameters ```wifi_ssid``` and ```location_permission```  ["granted", "denied", "do_not_ask_again"] to ```message_sent``` Firebase event. 
- Using SharedPreferences to store ```wifi_ssid```, and ```location_permission``` - updating them every time connection state or permission state changes.

![image](https://user-images.githubusercontent.com/28864717/59115984-6d733d00-8918-11e9-8504-128359e01fdc.png)


![image](https://user-images.githubusercontent.com/28864717/59115797-05bcf200-8918-11e9-927b-694c8c6efd76.png)


![image](https://user-images.githubusercontent.com/28864717/59115883-3735bd80-8918-11e9-8af4-30de70a920b5.png)
