### PR TITLE
[FIX] Add/Remove functionality initially does not display

### DIFF
--- a/app/src/main/java/chat/rocket/android/authentication/loginoptions/presentation/LoginOptionsPresenter.kt
+++ b/app/src/main/java/chat/rocket/android/authentication/loginoptions/presentation/LoginOptionsPresenter.kt
@@ -145,6 +145,7 @@ class LoginOptionsPresenter @Inject constructor(
                     )
                     localRepository.saveCurrentUser(url = currentServer, user = user)
                     saveCurrentServer.save(currentServer)
+                    localRepository.save(LocalRepository.CURRENT_USERNAME_KEY, username)
                     saveAccount(username)
                     saveToken(token)
                     analyticsManager.logLogin(loginMethod, true)


### PR DESCRIPTION
Closes #475 

#### Changes
Android client was not saving username in database after login with other options like sso. And this username is used to check permissions for add/remove users.



