### PR TITLE
need to log the state prior to launching a new thread 

### DIFF
--- a/app/src/main/java/chat/rocket/android/chatroom/presentation/ChatRoomPresenter.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/presentation/ChatRoomPresenter.kt
@@ -617,8 +617,9 @@ class ChatRoomPresenter @Inject constructor(
             for (state in stateChannel) {
                 Timber.d("Got new state: $state - last: $lastState")
                 if (state != lastState) {
+                    logConnectionStateChange(lastState, state)
                     launch(Dispatchers.Main) {
-                        logConnectionStateChange(lastState, state)
+
                         view.showConnectionState(state)
                     }
 


### PR DESCRIPTION
Or lastState gets overwritten. This fixes an issue I saw in firebase where lastState and newState had the same value.