### PR TITLE
use widechat search view in contacts pages

### DIFF
--- a/app/src/main/java/chat/rocket/android/chatroom/ui/Menu.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/ui/Menu.kt
@@ -9,12 +9,17 @@ import androidx.core.content.res.ResourcesCompat
 import chat.rocket.android.R
 import chat.rocket.android.util.extension.onQueryTextListener
 
+// WIDECHAT
+import android.graphics.Color
+import android.view.Gravity
+import android.widget.*
+import chat.rocket.android.helper.Constants
+
 internal fun ChatRoomFragment.setupMenu(menu: Menu) {
     setupSearchMessageMenuItem(menu, requireContext())
 }
 
 private fun ChatRoomFragment.setupSearchMessageMenuItem(menu: Menu, context: Context) {
-
     var actionFlags: Int? = null
     actionFlags = MenuItem.SHOW_AS_ACTION_IF_ROOM or MenuItem.SHOW_AS_ACTION_COLLAPSE_ACTION_VIEW
 
@@ -43,14 +48,42 @@ private fun ChatRoomFragment.setupSearchMessageMenuItem(menu: Menu, context: Con
 
     (searchItem.actionView as? SearchView)?.let {
         // TODO: Check why we need to stylize the search text programmatically instead of by defining it in the styles.xml (ChatRoom.SearchView)
-        it.maxWidth = Integer.MAX_VALUE
-        stylizeSearchView(it, context)
+        if (Constants.WIDECHAT) {
+            stylizeWidechatSearchView(it)
+        } else {
+            it.maxWidth = Integer.MAX_VALUE
+            stylizeSearchView(it, context)
+        }
         setupSearchViewTextListener(it)
         if (it.isIconified) {
             isSearchTermQueried = false
         }
     }
 }
+
+private fun stylizeWidechatSearchView(search: SearchView) {
+    search.setBackgroundResource(R.drawable.widechat_search_white_background)
+
+    val searchIcon: ImageView? = search.findViewById(R.id.search_mag_icon)
+    searchIcon?.setImageResource(R.drawable.ic_search_gray_24px)
+
+    val searchText: TextView? = search.findViewById<EditText>(androidx.appcompat.R.id.search_src_text)
+    searchText?.setTextColor(Color.GRAY)
+    searchText?.setHintTextColor(Color.GRAY)
+    searchText?.setHint( R.string.title_search_message)
+
+    val searchCloseButton: ImageView? = search.findViewById(R.id.search_close_btn)
+    searchText?.setOnFocusChangeListener { v, hasFocus ->
+        if (hasFocus)
+            searchCloseButton?.setImageResource(R.drawable.ic_close_gray_24dp)
+    }
+    searchCloseButton?.setOnClickListener { v ->
+        search.clearFocus()
+        search.setQuery("", false)
+        searchCloseButton?.setImageResource(0)
+    }
+}
+
 
 private fun stylizeSearchView(searchView: SearchView, context: Context) {
     val searchText = searchView.findViewById<EditText>(androidx.appcompat.R.id.search_src_text)

--- a/app/src/main/java/chat/rocket/android/chatroom/ui/Menu.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/ui/Menu.kt
@@ -11,7 +11,6 @@ import chat.rocket.android.util.extension.onQueryTextListener
 
 // WIDECHAT
 import android.graphics.Color
-import android.view.Gravity
 import android.widget.*
 import chat.rocket.android.helper.Constants
 

--- a/app/src/main/java/chat/rocket/android/chatrooms/ui/ChatRoomsFragment.kt
+++ b/app/src/main/java/chat/rocket/android/chatrooms/ui/ChatRoomsFragment.kt
@@ -144,6 +144,7 @@ class ChatRoomsFragment : Fragment(), ChatRoomsView {
             widechat_welcome_to_app.isVisible = false
             widechat_text_no_data_to_display.isVisible = false
             (activity as AppCompatActivity?)?.supportActionBar?.setDisplayShowTitleEnabled(false)
+            searchView?.onQueryTextListener { queryChatRoomsByName(it) }
             clearSearch()
         }
         setCurrentUserStatusIcon()

--- a/app/src/main/java/chat/rocket/android/contacts/ui/ContactsFragment.kt
+++ b/app/src/main/java/chat/rocket/android/contacts/ui/ContactsFragment.kt
@@ -2,7 +2,6 @@ package chat.rocket.android.contacts.ui
 
 import android.Manifest
 import android.content.pm.PackageManager
-import android.graphics.Color
 import android.os.Bundle
 import android.view.*
 import android.widget.ImageView
@@ -46,7 +45,6 @@ import chat.rocket.android.util.extensions.avatarUrl
 import chat.rocket.android.util.extensions.inflate
 import chat.rocket.android.util.extensions.showToast
 import chat.rocket.android.util.extensions.ui
-import com.facebook.drawee.view.SimpleDraweeView
 import dagger.android.support.AndroidSupportInjection
 import io.reactivex.Single
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -55,7 +53,6 @@ import io.reactivex.rxkotlin.subscribeBy
 import io.reactivex.schedulers.Schedulers
 import kotlinx.android.synthetic.main.app_bar.view.*
 import kotlinx.android.synthetic.main.fragment_contact_parent.*
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -273,7 +270,7 @@ class ContactsFragment : Fragment(), ContactsView {
             }
         }
     }
-    
+
     fun containsIgnoreCase(src: String, what: String): Boolean {
         val length = what.length
         if (length == 0)

--- a/app/src/main/java/chat/rocket/android/contacts/ui/ContactsFragment.kt
+++ b/app/src/main/java/chat/rocket/android/contacts/ui/ContactsFragment.kt
@@ -98,11 +98,6 @@ class ContactsFragment : Fragment(), ContactsView {
     private var finalList: ArrayList<ItemHolder<*>> = ArrayList()
     private var contactsSelectionTracker: SelectionTracker<Long>? = null
     private var selectedContacts: ArrayList<Contact> = ArrayList()
-
-    private var searchView: SearchView? = null
-    private var searchIcon: ImageView? = null
-    private var searchText: TextView? = null
-    private var searchCloseButton: ImageView? = null
     private var loadedOnce: Boolean = false
     var enableGroups: Boolean = false
 
@@ -266,6 +261,9 @@ class ContactsFragment : Fragment(), ContactsView {
                 val profileButtonLayout: ConstraintLayout? = this?.getCustomView()?.findViewById(R.id.rl_image_avatar)
                 profileButtonLayout?.visibility = GONE
                 val searchView: SearchView? = this?.getCustomView()?.findViewById(R.id.action_widechat_search)
+                searchView?.clearFocus()
+                val searchCloseButton: ImageView? = searchView?.findViewById(R.id.search_close_btn)
+                searchCloseButton?.setImageResource(0)
                 searchView?.onQueryTextListener { queryContacts(it) }
             }
         }

--- a/app/src/main/java/chat/rocket/android/createchannel/ui/CreateChannelFragment.kt
+++ b/app/src/main/java/chat/rocket/android/createchannel/ui/CreateChannelFragment.kt
@@ -279,6 +279,7 @@ class CreateChannelFragment : Fragment(), CreateChannelView, ActionMode.Callback
             (activity as MainActivity).toolbar.setNavigationContentDescription(R.string.go_back_button_description)
             (activity as MainActivity).toolbar.setNavigationOnClickListener {
                 activity?.onBackPressed()
+                widechatSearchView?.visibility = View.VISIBLE
             }
         } else {
             with((activity as AppCompatActivity?)?.supportActionBar) {

--- a/app/src/main/res/drawable/ic_refresh_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_refresh_black_24dp.xml
@@ -1,5 +1,0 @@
-<vector android:height="24dp" android:tint="#000000"
-    android:viewportHeight="24.0" android:viewportWidth="24.0"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#FF000000" android:pathData="M17.65,6.35C16.2,4.9 14.21,4 12,4c-4.42,0 -7.99,3.58 -7.99,8s3.57,8 7.99,8c3.73,0 6.84,-2.55 7.73,-6h-2.08c-0.82,2.33 -3.04,4 -5.65,4 -3.31,0 -6,-2.69 -6,-6s2.69,-6 6,-6c1.66,0 3.14,0.69 4.22,1.78L13,11h7V4l-2.35,2.35z"/>
-</vector>

--- a/app/src/main/res/drawable/ic_refresh_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_refresh_white_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#ffffff" android:pathData="M17.65,6.35C16.2,4.9 14.21,4 12,4c-4.42,0 -7.99,3.58 -7.99,8s3.57,8 7.99,8c3.73,0 6.84,-2.55 7.73,-6h-2.08c-0.82,2.33 -3.04,4 -5.65,4 -3.31,0 -6,-2.69 -6,-6s2.69,-6 6,-6c1.66,0 3.14,0.69 4.22,1.78L13,11h7V4l-2.35,2.35z"/>
+</vector>

--- a/app/src/main/res/menu/widechat_contacts.xml
+++ b/app/src/main/res/menu/widechat_contacts.xml
@@ -5,25 +5,8 @@
     tools:context=".main.ui.MainActivity">
 
     <item
-        android:id="@+id/action_search"
-        android:icon="@drawable/ic_search_white_24dp"
-        android:title="@string/action_search"
-        app:actionViewClass="androidx.appcompat.widget.SearchView"
-        app:showAsAction="ifRoom|collapseActionView" />
-
-    <item
-        android:id="@+id/action_more"
-        android:icon="@drawable/ic_more_vert_white_24dp"
-        android:title="More..."
-        android:orderInCategory="100"
-        app:showAsAction="always">
-        <menu>
-            <item
-                android:id="@+id/action_refresh"
-                android:icon="@drawable/ic_refresh_black_24dp"
-                android:title="Refresh"
-                app:showAsAction="never" />
-        </menu>
-    </item>
-
+        android:id="@+id/action_refresh"
+        android:icon="@drawable/ic_refresh_white_24dp"
+        android:title="Refresh"
+        app:showAsAction="always" />
 </menu>


### PR DESCRIPTION
- Search is now expanded by default in the NewChat and NewGroup pages
- Pulled the refresh button out of the overflow menu
- Use widechat search view in the message search