### PR TITLE
fix share via app to work when offline

### DIFF
--- a/app/src/main/java/chat/rocket/android/helper/ShareAppHelper.kt
+++ b/app/src/main/java/chat/rocket/android/helper/ShareAppHelper.kt
@@ -10,9 +10,6 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-//test
-import timber.log.Timber
-
 class ShareAppHelper @Inject constructor(
 	private val dynamicLinksManager: DynamicLinksForFirebase,
 	private val serverInteractor: GetCurrentServerInteractor,

--- a/app/src/main/java/chat/rocket/android/helper/ShareAppHelper.kt
+++ b/app/src/main/java/chat/rocket/android/helper/ShareAppHelper.kt
@@ -10,6 +10,9 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+//test
+import timber.log.Timber
+
 class ShareAppHelper @Inject constructor(
 	private val dynamicLinksManager: DynamicLinksForFirebase,
 	private val serverInteractor: GetCurrentServerInteractor,
@@ -23,15 +26,21 @@ class ShareAppHelper @Inject constructor(
 			val userName = account.userName
 
 			val deepLinkCallback = { returnedString: String? ->
+				var text_content = context.getString(R.string.default_invitation_text_description)
+				if (returnedString == null) {
+					text_content = text_content + " " + context.getString(R.string.default_invitation_text_app_store)
+				} else {
+					text_content = text_content + " " + String.format(context.getString(R.string.default_invitation_text_dynamic_link), returnedString)
+				}
+
 				with(Intent(Intent.ACTION_SEND)) {
 					type = "text/plain"
 					putExtra(Intent.EXTRA_SUBJECT, String.format(context.getString(R.string.default_invitation_subject), userName))
-					putExtra(Intent.EXTRA_TEXT, String.format(context.getString(R.string.default_invitation_text), returnedString))
+					putExtra(Intent.EXTRA_TEXT, text_content)
 					context.startActivity(Intent.createChooser(this, context.getString(R.string.msg_share_using)))
 				}
 			}
 			dynamicLinksManager.createDynamicLink(userName, server, deepLinkCallback)
 		}
 	}
-
 }

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -396,7 +396,9 @@
     <string name="save">GUARDAR</string>
     <string name="no_thanks">NO GRACIAS</string>
     <string name="chat_with">Chat con %1$s en %2$s</string>
-    <string name="default_invitation_text">Viasat Connect es una aplicación nueva que me facilita mensajear con amigos y familiares. Descarga la aplicación aquí %1$s y conéctate conmigo.</string>
+    <string name="default_invitation_text_description">Viasat Connect es una nueva aplicación que me facilita enviar mensajes de texto con amigos y familiares.</string>
+    <string name="default_invitation_text_dynamic_link">Descargue la aplicación aquí %1$s o consíguela buscando en Google Play Store y conéctese conmigo.</string>
+    <string name="default_invitation_text_app_store">Descargue la aplicación desde Google Play Store y conéctese conmigo.</string>
     <string name="default_invitation_subject">Tu amigo %1$s te ha invitado a chatear en Viasat Connect</string>
 
     <!--WIDECHAT PERMISSIONS-->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -397,7 +397,7 @@
     <string name="no_thanks">NO GRACIAS</string>
     <string name="chat_with">Chat con %1$s en %2$s</string>
     <string name="default_invitation_text_description">Viasat Connect es una nueva aplicación que me facilita chatear con amigos y familiares.</string>
-    <string name="default_invitation_text_dynamic_link">Descargue la aplicación aquí %1$so busque Viasat Connect en Google Play Store y conéctese conmigo.</string>
+    <string name="default_invitation_text_dynamic_link">Descargue la aplicación aquí %1$s o busque Viasat Connect en Google Play Store y conéctese conmigo.</string>
     <string name="default_invitation_text_app_store">Descargue la aplicación buscando Viasat Connect en Google Play Store para chatear conmigo.</string>
     <string name="default_invitation_subject">Tu amigo %1$s te ha invitado a chatear en Viasat Connect</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -396,9 +396,9 @@
     <string name="save">GUARDAR</string>
     <string name="no_thanks">NO GRACIAS</string>
     <string name="chat_with">Chat con %1$s en %2$s</string>
-    <string name="default_invitation_text_description">Viasat Connect es una nueva aplicación que me facilita enviar mensajes de texto con amigos y familiares.</string>
-    <string name="default_invitation_text_dynamic_link">Descargue la aplicación aquí %1$s o consíguela buscando en Google Play Store y conéctese conmigo.</string>
-    <string name="default_invitation_text_app_store">Descargue la aplicación desde Google Play Store y conéctese conmigo.</string>
+    <string name="default_invitation_text_description">Viasat Connect es una nueva aplicación que me facilita chatear con amigos y familiares.</string>
+    <string name="default_invitation_text_dynamic_link">Descargue la aplicación aquí %1$so busque Viasat Connect en Google Play Store y conéctese conmigo.</string>
+    <string name="default_invitation_text_app_store">Descargue la aplicación buscando Viasat Connect en Google Play Store para chatear conmigo.</string>
     <string name="default_invitation_subject">Tu amigo %1$s te ha invitado a chatear en Viasat Connect</string>
 
     <!--WIDECHAT PERMISSIONS-->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -424,7 +424,9 @@ https://github.com/RocketChat/java-code-styles/blob/master/CODING_STYLE.md#strin
     <string name="save">SAVE</string>
     <string name="no_thanks">NO THANKS</string>
     <string name="chat_with">Chat with %1$s on %2$s</string>
-    <string name="default_invitation_text">Viasat Connect is a new application that makes it easy for me to text with friends and family. Download the application here %1$s and connect with me.</string>
+    <string name="default_invitation_text_description">Viasat Connect is a new application that makes it easy for me to text with friends and family.</string>
+    <string name="default_invitation_text_dynamic_link">Download the application here %1$s or get it by searching in the Google Play Store and connect with me.</string>
+    <string name="default_invitation_text_app_store">Download the application from the Google Play Store and connect with me.</string>
     <string name="default_invitation_subject">Your friend %1$s has invited you to chat on Viasat Connect</string>
 
     <!--WIDECHAT PERMISSIONS-->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -424,9 +424,9 @@ https://github.com/RocketChat/java-code-styles/blob/master/CODING_STYLE.md#strin
     <string name="save">SAVE</string>
     <string name="no_thanks">NO THANKS</string>
     <string name="chat_with">Chat with %1$s on %2$s</string>
-    <string name="default_invitation_text_description">Viasat Connect is a new application that makes it easy for me to text with friends and family.</string>
-    <string name="default_invitation_text_dynamic_link">Download the application here %1$s or get it by searching in the Google Play Store and connect with me.</string>
-    <string name="default_invitation_text_app_store">Download the application from the Google Play Store and connect with me.</string>
+    <string name="default_invitation_text_description">Viasat Connect is a new application that makes it easy for me to chat with friends and family.</string>
+    <string name="default_invitation_text_dynamic_link">Download the application here %1$s or search for Viasat Connect in the Google Play Store and connect with me.</string>
+    <string name="default_invitation_text_app_store">Download the application by searching for Viasat Connect in the Google Play Store to chat with me.</string>
     <string name="default_invitation_subject">Your friend %1$s has invited you to chat on Viasat Connect</string>
 
     <!--WIDECHAT PERMISSIONS-->

--- a/app/src/play/java/chat/rocket/android/dynamiclinks/DynamicLinksForFirebase.kt
+++ b/app/src/play/java/chat/rocket/android/dynamiclinks/DynamicLinksForFirebase.kt
@@ -46,13 +46,16 @@ class DynamicLinksForFirebase @Inject constructor(private var context: Context) 
             .addOnSuccessListener { result ->
                 newDeepLink = result.shortLink.toString()
                 Timber.d("New deeplink created: ${newDeepLink}")
-                deepLinkCallback(newDeepLink)
 
             }.addOnFailureListener {
                 // Error
                 Timber.d("Error creating dynamic link.")
+
+            }.addOnCompleteListener {
+                deepLinkCallback(newDeepLink)
             }
     }
+
 }
 
 


### PR DESCRIPTION
Currently if the user is offline and cannot reach firebase, dynamicLink creation fails, and the share intent is never actually called......  so no invite was possible at all. 

Now the intent is always called, even when offline, and a substitute message is used if no dynamic link exists.  Two added benefits:
- If a dynamic link has ever been created, it will persist for the lifetime of the app process, and will be re-used, even when offline. 
- Since the share intent has been triggered, the sharing app is now responsible for the invite and will usually hang on to it and send it the next time the user is connected to the internet (Gmail and WhatsApp for example)